### PR TITLE
fix: lua repl now properly handles multi-line statements

### DIFF
--- a/src/events.zig
+++ b/src/events.zig
@@ -105,13 +105,7 @@ test "init" {
 }
 
 pub fn loop() !void {
-    defer allocator.free(pool);
-    //  var event = try new(Event.Exec_Code_Line);
-    //  var line = try allocator.allocSentinel(u8, 6, 0);
-    //  std.mem.copyForwards(u8, line, "init()");
-    //  event.Exec_Code_Line.line = line;
-    //  try post(event);
-
+    std.debug.print("> ", .{});
     while (!quit) {
         queue.lock.lock();
         while (queue.size == 0) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,7 +13,7 @@ const input = @import("input.zig");
 const screen = @import("screen.zig");
 const c = @import("c_includes.zig").imported;
 
-const VERSION = std.builtin.Version{ .major = 0, .minor = 4, .patch = 1 };
+const VERSION = std.builtin.Version{ .major = 0, .minor = 4, .patch = 2 };
 
 pub fn main() !void {
     defer std.debug.print("seamstress shutdown complete\n", .{});


### PR DESCRIPTION
noticed that something like
```lua
for i = 1, 3 do
print(i)
end
```
would fail to properly output
```lua
1
2
3
```
so I fixed that. I also happen to dislike maiden's `<ok>`, so I made a prompt instead