### PR TITLE
fix: monome device stability issues

### DIFF
--- a/src/c_includes.zig
+++ b/src/c_includes.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 pub const imported = @cImport({
     @cInclude("monome.h");
+    @cInclude("pthread.h");
     @cInclude("lo/lo.h");
     @cInclude("dns_sd.h");
     @cInclude("SDL2/SDL.h");


### PR DESCRIPTION
this PR should prevent the grid from becoming unresponsive after being mashed while still exiting properly.
long-term, it might be appropriate to look into changing `libmonome` or seeing what native capabilities Zig affords for cancelling threads rather than dropping down to C.