### PR TITLE
fix: print errors in user script pre-`init`

### DIFF
--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -32,9 +32,11 @@ _seamstress.monome = {
 --- startup function; called by spindle to start the script.
 -- @tparam string script_file set by calling seamstress with `-s filename`
 _startup = function (script_file)
-  if not pcall(require, script_file) then
+  if not util.exists(script_file..'.lua') then
     print("seamstress was unable to find user-provided " .. script_file .. ".lua file!")
     print("create such a file and place it in either CWD or ~/seamstress")
+  else
+    require(script_file)
+    init()
   end
-  init()
 end

--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -32,7 +32,7 @@ _seamstress.monome = {
 --- startup function; called by spindle to start the script.
 -- @tparam string script_file set by calling seamstress with `-s filename`
 _startup = function (script_file)
-  if not util.exists(script_file..'.lua') then
+  if not util.exists(script_file..'.lua') and not util.exists(path.seamstress .. '/' .. script_file .. '.lua')then
     print("seamstress was unable to find user-provided " .. script_file .. ".lua file!")
     print("create such a file and place it in either CWD or ~/seamstress")
   else

--- a/src/spindle.zig
+++ b/src/spindle.zig
@@ -1043,9 +1043,9 @@ fn docall(l: *Lua, nargs: i32, nres: i32) !void {
     l.pushFunction(ziglua.wrap(message_handler));
     l.insert(base);
     l.protectedCall(nargs, nres, base) catch {
-        const msg = try l.toString(-1);
-        std.debug.print("{s}\n", .{msg});
-        l.pop(1);
+        l.remove(base);
+        try lua_print(l);
+        return;
     };
     l.remove(base);
 }


### PR DESCRIPTION
I noticed that `pcall` appeared to be capturing any (user-caused) errors that occurred in the main body of `script.lua` (or any files called at the top w/ `dofile`), rather than printing them in the REPL, which caused some momentary confusion for me.

since the nature of that check & error messages appeared to be more about checking for the existence of the file, regardless of error-free-ness, I tried just dogfooding off of `util.exists` and using a non-protected `require` only if the file exists.

not totally sure if this was a bug or intended behavior, but regardless, this new behavior matches my personal expectations better, at least :)