### PR TITLE
add all non-graphic, non norns-weaver dependant libs

### DIFF
--- a/lua/config.lua
+++ b/lua/config.lua
@@ -25,3 +25,11 @@ path = {
 }
 
 _old_print = print
+
+-- norns compatibility fns
+
+-- as currently seamstress doesn't allow to switch scripts at runtime,
+-- PWD got added to package.path, making this fn a simple alias
+function include(file)
+  return require(file)
+end

--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -42,7 +42,7 @@ _seamstress.monome = {
 --- startup function; called by spindle to start the script.
 -- @tparam string script_file set by calling seamstress with `-s filename`
 _startup = function (script_file)
-  if not util.exists(script_file..'.lua') and not util.exists(path.seamstress .. '/' .. script_file .. '.lua')then
+  if not util.file_exists(script_file..'.lua') and not util.file_exists(path.seamstress .. '/' .. script_file .. '.lua')then
     print("seamstress was unable to find user-provided " .. script_file .. ".lua file!")
     print("create such a file and place it in either CWD or ~/seamstress")
   else

--- a/lua/lib/asl.lua
+++ b/lua/lib/asl.lua
@@ -1,0 +1,128 @@
+-- crow asl string building helper functions
+-- @module crow.asl
+--
+-- for the common case, these functions make interactions
+-- w/ crow look the same on norns as in druid.
+--
+-- for example, common commands like:
+--
+-- ```
+--    crow.output[1].action = { to(0,0), to(5,0.1), to(1,2) }
+--    crow.output[1].action = times(4, { to(0,0), to(5,0.1), to(1,2) } )
+--    crow.output[1].action = loop{ to(0,0), to(5,0.1), to(1,2) }
+--    crow.output[1].action = lfo(1, 5)
+--    crow.output[1].action = ar(1, 5)
+--    crow.output[1].action = pulse(1, 5, 1)
+--    crow.output[1].action = adsr(0.1, 0.5, 2, 2)
+--    crow.output[1].action = { held{to(5.0, 1), to(1, 2)}, to(0, 1) }
+-- ```
+--
+-- work as expected.
+--
+-- things differ in the "dynamic case" where a script writer wants to assign
+-- custom behavior to a crow output.  for example:
+--
+--     `crow.output[1].action = ar(1, math.random(5))`
+--
+-- has different behavior executed on norns vs. crow:
+--
+--   * on norns, `math.random(5)` is executed once and the result assigned to the
+--     envelope's release segment
+--   * on crow, `math.random(5)` is executed fresh on each triggering of the action
+--
+-- to get the dynamic re-evaluating behavior on norns, the idiom is to send the asl
+-- directly to crow like this:
+--
+-- ```
+--    crow.send[[
+--      output[1].action = ar(1, math.random(5))
+--    ]]
+-- ```
+--
+-- (note that `[[` and `]]` delimit mult-line strings in Lua.)
+--
+--
+-- todo(pq): add luadocs for functions
+-- todo(pq): consider reporting missing required args
+--
+local function as_arg_string(args, as_table)
+  local arg_string = ''
+  for _, arg in ipairs(args) do
+    if arg then
+      if string.len(arg_string) ~= 0 then
+        arg_string = arg_string .. ', '
+      end
+      arg_string = arg_string .. arg
+    end
+  end
+  if as_table then
+    return '{' .. arg_string .. '}'
+  else
+    return '(' .. arg_string .. ')'
+  end
+end
+
+local function func(fun, args, as_table)
+  return fun .. as_arg_string(args, as_table)
+end
+
+function ar(attack, release, level)
+  return func('ar', {attack, release, level})
+end
+
+function pulse(time, level, polarity)
+  return func('pulse', {time, level, polarity})
+end
+
+function ramp(time, skew, level)
+  return func('ramp', {time, skew, level})
+end
+
+function to(dest, time, shape)
+  return func('to', {dest, time, shape})
+end
+
+function lfo(hz, amp)
+  return func('lfo', {hz, amp})
+end
+
+function loop(asl)
+  return func('loop', asl, true)
+end
+
+function adsr(attack, decay, sustain, release)
+  return func('adsr', {attack, decay, sustain, release})
+end
+
+function note(noteNum, duration)
+  return func('note', {noteNum, duration})
+end
+
+function n2v(n)
+  return func('n2v', {n})
+end
+
+function negate(v)
+  return func('negate', {v})
+end
+
+function boundgz(n)
+  return func('boundgz', {n})
+end
+
+function div(n, d)
+  return func('div', {n, d})
+end
+
+function times(count, asl)
+  local arg_string = as_arg_string(asl, true)
+  return 'times(' .. count .. ', ' .. arg_string .. ')'
+end
+
+function lock(fns)
+  return func('lock', fns, true)
+end
+
+function held(fns)
+  return func('held', fns, true)
+end

--- a/lua/lib/beatclock.lua
+++ b/lua/lib/beatclock.lua
@@ -1,0 +1,175 @@
+--- BeatClock
+-- @module lib.BeatClock
+
+local BeatClock = {}
+BeatClock.__index = BeatClock
+
+--- constructor
+-- @tparam string name
+-- @treturn BeatClock
+function BeatClock.new(name)
+  local i = {}
+  setmetatable(i, BeatClock)
+  
+  i.name = name or ""
+  i.playing = false
+  i.ticks_per_step = 6
+  i.current_ticks = i.ticks_per_step - 1
+  i.steps_per_beat = 4
+  i.beats_per_bar = 4
+  i.step = i.steps_per_beat - 1
+  i.beat = i.beats_per_bar - 1
+  i.external = false
+  i.send = false
+  i.midi = false
+  
+  i.metro = metro.init()
+  i.metro.count = -1
+  i.metro.event = function() i:tick() end
+  i:bpm_change(110)
+
+  i.on_step = function(e) print("BeatClock executing step") end
+  i.on_start = function(e) end
+  i.on_stop = function(e) end
+  i.on_select_internal = function(e) print("BeatClock using internal clock") end
+  i.on_select_external = function(e) print("BeatClock using external clock") end
+  
+  i:enable_midi()
+
+  return i
+end
+
+--- start
+function BeatClock:start(dev_id)
+  self.playing = true
+  if not self.external then
+    self.metro:start()
+  end
+  self.current_ticks = self.ticks_per_step - 1
+  if self.midi and self.send then
+    for id, device in pairs(midi.devices) do
+      if id ~= dev_id then
+        device:send({251})
+      end
+    end
+  end
+  self.on_start()
+end
+
+--- stop
+function BeatClock:stop(dev_id)
+  self.playing = false
+  self.metro:stop()
+  if self.midi and self.send then
+    for id, device in pairs(midi.devices) do
+      if id ~= dev_id then
+        device:send({252})
+      end
+    end
+  end
+  self.on_stop()
+end
+
+--- advance step
+function BeatClock:advance_step()
+  self.step = (self.step + 1) % self.steps_per_beat
+  if self.step == 0 then
+    self.beat = (self.beat + 1) % self.beats_per_bar
+  end
+  self.on_step()
+end
+
+--- tick
+function BeatClock:tick(dev_id)
+  self.current_ticks = (self.current_ticks + 1) % self.ticks_per_step
+  if self.playing and self.current_ticks == 0 then
+    self:advance_step()
+  end
+  
+  if self.midi and self.send then
+    for id, device in pairs(midi.devices) do
+      if id ~= dev_id then
+        device:send({248})
+      end
+    end
+  end
+end
+
+--- reset
+function BeatClock:reset(dev_id)
+  self.step = self.steps_per_beat - 1
+  self.beat = self.beats_per_bar - 1
+  self.current_ticks = self.ticks_per_step - 1
+  if self.midi and self.send then
+    for id, device in pairs(midi.devices) do
+      if id ~= dev_id then
+        device:send({250})
+        if not self.playing then -- force reseting while stopped requires a start/stop (??)
+          device:send({252})
+        end
+      end
+    end
+  end
+end
+
+--- clock source change
+function BeatClock:clock_source_change(source)
+  self.current_ticks = self.ticks_per_step - 1
+  if source == 1 then
+    self.external = false
+    if self.playing then
+      self.metro:start()
+    end
+    self.on_select_internal()
+  else
+    self.external = true
+    self.metro:stop()
+    self.on_select_external()
+  end
+end
+
+--- bpm change
+function BeatClock:bpm_change(bpm)
+  self.bpm = bpm
+  self.metro.time = 60/(self.ticks_per_step * self.steps_per_beat * self.bpm)
+end
+
+--- add clock params
+function BeatClock:add_clock_params()
+  params:add_option("clock", "clock", {"internal", "external"}, self.external or 2 and 1)
+  params:set_action("clock", function(x) self:clock_source_change(x) end)
+  params:add_number("bpm", "bpm", 1, 480, self.bpm)
+  params:set_action("bpm", function(x) self:bpm_change(x) end)
+  params:add_option("clock_out", "clock out", { "no", "yes" }, self.send or 2 and 1)
+  params:set_action("clock_out", function(x) if x == 1 then self.send = false else self.send = true end end)
+end
+
+--- enable midi
+function BeatClock:enable_midi()
+  self.midi = true  
+end
+
+--- process midi
+function BeatClock:process_midi(data)
+  if self.midi then
+    local status = data[1]
+    local data1 = data[2]
+    local data2 = data[3]
+  
+    if self.external then 
+      if status == 248 then -- midi clock
+        self:tick(id)
+      elseif status == 250 then -- midi clock start
+        self:reset(id)
+        self:start(id)
+      elseif status == 251 then -- midi clock continue
+        self:start(id)
+      elseif status == 252 then -- midi clock stop
+        self:stop(id)
+      end
+    end 
+  end
+end
+
+  
+return BeatClock

--- a/lua/lib/container/TESTING.md
+++ b/lua/lib/container/TESTING.md
@@ -1,0 +1,8 @@
+TODO: the tests should be made more easily runnable. currently one must manually
+run each container test script individually by:
+
+- `cd norns/lua`
+- `LUA_PATH='lib/?.lua' lua5.3 lib/container/<name_of_container>_test.lua -v`
+
+NB: norns/matron embed lua5.3 while the base os install only includes the lua5.1
+interpreter. to test using lua5.3 as above run `sudo apt-get install lua5.3`

--- a/lua/lib/container/defaulttable.lua
+++ b/lua/lib/container/defaulttable.lua
@@ -1,0 +1,75 @@
+-- DefaultTable - a table which provides a default value initialization for each key
+-- @module DefaultTable
+-- @alias DefaultTable
+
+local function shallow_copy(t)
+  -- MAINT: the {table.unpack(t)} trick doesn't work if the given table has
+  -- non-integer keys or a numeric indicies with gaps
+  local new = {}
+  for k,v in pairs(t) do
+    new[k] = v
+  end
+  return new
+end
+
+local DefaultTable = {}
+DefaultTable.__index = DefaultTable
+
+--- Create a table where every key is inialized with a default value when first
+-- accessed.
+--
+-- Providing a table as the initial value will result in a shallow copy of the
+-- given table being made when a key is initially accessed. Providing a (zero
+-- argument) function will result in the function being called to obtain the
+-- initial value. Providing any other value will result in that value being
+-- used as the initial value for keys (which could result structural sharing
+-- between keys).
+--
+-- @tparam anything initial Value initializer (can be nil).
+-- @treturn table
+function DefaultTable.new(initial)
+  local self = {}
+  self._table = {}
+
+  local t = type(initial)
+  if t == 'table' then
+    self._initializer = function() return shallow_copy(initial) end
+  elseif t == 'function' then
+    self._initializer = initial
+  else
+    self._initializer = function() return initial end
+  end
+
+  setmetatable(self, DefaultTable)
+
+  return self
+end
+
+function DefaultTable:__index(k)
+  local _t = rawget(self, '_table')
+  local v = _t[k]
+  if v == nil then
+    local _i = rawget(self, '_initializer')
+    v = _i()
+    _t[k] = v
+  end
+  return v
+end
+
+function DefaultTable:__newindex(k, v)
+  rawget(self, '_table')[k] = v
+end
+
+function DefaultTable:__len()
+  return #self._table
+end
+
+function DefaultTable.__pairs(this)
+  return pairs(rawget(this, '_table'))
+end
+
+function DefaultTable.__ipairs(this)
+  return ipairs(rawget(this, '_table'))
+end
+
+return DefaultTable

--- a/lua/lib/container/defaulttable_test.lua
+++ b/lua/lib/container/defaulttable_test.lua
@@ -1,0 +1,92 @@
+T = require 'test/luaunit'
+DefaultTable = dofile('lib/container/defaulttable.lua')
+
+--
+-- tests
+--
+
+function test_new_no_args()
+  local dt = DefaultTable.new()
+  T.assertNotNil(dt)
+  T.assertNil(dt['a'])
+  dt['a'] = 1
+  T.assertEquals(dt['a'], 1)
+end
+
+function test_new_with_table_literal()
+  local dt = DefaultTable.new({'a', 'b', 'c'})
+  T.assertEquals(dt['key1'][1], 'a')
+  T.assertEquals(dt['key1'][3], 'c')
+
+  -- ensure different key also has table
+  T.assertEquals(dt['key2'][3], 'c')
+
+  -- ensure keys have different tables
+  dt['key1'][3] = 'changed'
+  T.assertEquals(dt['key2'][3], 'c')
+  T.assertNotEquals(dt['key1'], dt['key2'])
+end
+
+function test_new_with_function()
+  local initializer = function()
+    return { x = 1, y = -16 }
+  end
+
+  local default = initializer()
+  local dt = DefaultTable.new(initializer)
+
+  T.assertEquals(dt['random'], default)
+  dt.random.x = 100
+  T.assertEquals(dt['random']['x'], 100)
+end
+
+function test_len()
+  local dt = DefaultTable.new('value')
+  T.assertEquals(#dt, 0)
+  local v1 = dt[1]
+  T.assertEquals(#dt, 1)
+  local v2 = dt[2]
+  T.assertEquals(#dt, 2)
+
+  -- NB: like ipairs, # stops counting at the first index with a nil value
+  local other = dt[131]
+  T.assertEquals(#dt, 2)
+end
+
+function test_ipairs()
+  local dt = DefaultTable.new()
+  dt[1] = 'first'
+  dt[2] = 'second'
+  dt[3] = 'last'
+  dt[34] = 'not reached'
+
+  local iter, t, i = ipairs(dt)
+  local i, v = iter(t, i)
+  T.assertEquals(v, 'first')
+  local i, v = iter(t, i)
+  T.assertEquals(v, 'second')
+  local i, v = iter(t, i)
+  T.assertEquals(v, 'last')
+  local i, v = iter(t, i)
+  T.assertNil(v)
+end
+
+function test_pairs()
+  local dt = DefaultTable.new()
+  dt['a'] = 'first'
+  dt[2] = 1234
+  dt[{}] = 'other'
+
+  local keys = {}
+  local values = {}
+
+  for k,v in pairs(dt) do
+    table.insert(keys, k)
+    table.insert(values, v)
+  end
+
+  T.assertItemsEquals(keys, {'a', 2, {}})
+  T.assertItemsEquals(values, {1234, 'first', 'other'})
+end
+
+os.exit(T.LuaUnit.run())

--- a/lua/lib/container/deque.lua
+++ b/lua/lib/container/deque.lua
@@ -1,0 +1,249 @@
+-- deque - double ended queue
+-- @module deque
+-- @alias Deque
+
+-- reference: https://www.lua.org/pil/11.4.html
+
+
+local REMOVED = { 'deque removed value' }
+
+local Deque = {}
+Deque.__index = Deque
+
+--- Create a Deque value (object).
+--
+-- A double ended queue supporting O(1) insertion at the head or tail of the queue.
+--
+-- @tparam table elements Initial values to shallow copy into queue [optional]
+-- @treturn Deque instance
+function Deque.new(elements)
+  local o = setmetatable({}, Deque)
+  o.first = 0
+  o.last = -1
+  o.tombstones = 0
+  o._e = {}
+  if elements ~= nil then
+    for _, e in ipairs(elements) do
+      o:push_back(e)
+    end
+  end
+  return o
+end
+
+--- Push a value onto the front of the queue
+-- @tparam anything value The value to insert
+function Deque:push(value)
+  local first = self.first - 1
+  self.first = first
+  self._e[first] = value
+end
+
+--- Push a value onto the back of the queue
+-- @tparam anything value The value to insert
+function Deque:push_back(value)
+  local last = self.last + 1
+  self.last = last
+  self._e[last] = value
+end
+
+--- Push all values from another Deque onto theback of this one
+-- @tparam Deque other_deque The values to insert
+function Deque:extend_back(other_deque)
+  for _, e in other_deque:ipairs() do
+    self:push_back(e)
+  end
+end
+
+--- Pop the value off the front of the queue and return it
+-- @treturn anything
+function Deque:pop()
+  local first = self.first
+  if first > self.last then
+    -- empty
+    return nil
+  end
+  local value = self._e[first]
+  self._e[first] = nil
+  self.first = first + 1
+  if value ~= REMOVED then
+    return value
+  end
+  -- tail call to skip over tombstone
+  self.tombstones = self.tombstones - 1
+  return self:pop()
+end
+
+-- Peek at the value n elements from the front
+-- @treturn anything
+function Deque:peek(n)
+  local pos = self.first + (n or 1) - 1
+  if pos > self.last then
+    return nil -- empty
+  end
+  while pos <= self.last do
+    local value = self._e[pos]
+    if value ~= REMOVED then return value end
+    pos = pos + 1
+  end
+  return nil
+end
+
+--- Pop the value off the back of the queue and return it
+-- @treturn anything
+function Deque:pop_back()
+  local last = self.last
+  if self.first > last then
+    -- empty
+    return nil
+  end
+  local value = self._e[last]
+  self._e[last] = nil
+  self.last = last - 1
+  if value ~= REMOVED then
+    return value
+  end
+  -- tail call to skip over tombstone
+  self.tombstones = self.tombstones - 1
+  return self:pop_back()
+end
+
+-- Peek at the value n elements from the back
+-- @treturn anything
+function Deque:peek_back(n)
+  local pos = self.last - ((n or 1) - 1)
+  if pos < self.first then
+    return nil -- empty
+  end
+  while pos >= self.first do
+    local value = self._e[pos]
+    if value ~= REMOVED then return value end
+    pos = pos - 1
+  end
+  return nil
+end
+
+local function _eq(a, b)
+  return a == b
+end
+
+--- Returns the queued value if the a match is found.
+--
+-- The optional predicate function should take two arguments and return true
+-- if the arguments are considered a match. The default predicate is ==.
+--
+-- @tparam anything value The value to search the queue for
+-- @tparam function predicate Comparison function [optional]
+-- @treturn anything
+function Deque:find(value, predicate)
+  predicate = predicate or _eq
+  for _, v in self:ipairs() do
+    if predicate(v, value) then
+      return v
+    end
+  end
+  return nil
+end
+
+--- Returns true if the given value is in the queue.
+--
+-- The optional predicate function should take two arguments and return true
+-- if the arguments are considered a match. The default predicate is ==.
+--
+-- @tparam anything value The value to search the queue for
+-- @tparam function predicate Comparison function [optional]
+-- @treturn boolean
+function Deque:contains(value, predicate)
+  return self:find(value, predicate) ~= nil
+end
+
+--- Removes the first instance over value in the queue
+--
+-- The optional predicate function should take two arguments and return true
+-- if the arguments are considered a match. The default predicate is ==.
+--
+-- @tparam anything value The value to remove from the queue
+-- @tparam function predicate Comparison function [optional]
+-- @treturn anything Removed value or nil
+function Deque:remove(value, predicate)
+  predicate = predicate or _eq
+
+  -- optimal case (match head or tail)
+  if predicate(self._e[self.first], value) then
+    return self:pop()
+  elseif predicate(self._e[self.last], value) then
+    return self:pop_back()
+  end
+
+  -- search for a match and tombstone it
+  local i = self.first
+  while i <= self.last do
+    local e = self._e[i]
+    if e ~= REMOVED and predicate(e, value) then
+      self._e[i] = REMOVED
+      self.tombstones = self.tombstones + 1
+      return e
+    end
+    i = i + 1
+  end
+
+  return nil
+end
+
+--- Return the number of elements/values in the queue
+-- @treturn int
+function Deque:count()
+  if self.last < self.first then
+    return 0
+  end
+  return self.last - self.first - self.tombstones + 1
+end
+
+--- Clear out all elements in the queue
+function Deque:clear()
+  self._e = {}
+  -- must match new()
+  self.first = 0
+  self.last = -1
+  self.tombstones = 0
+end
+
+--- Returns an iterator for the queue which behaves like ipairs
+-- @treturn function
+function Deque:ipairs()
+  local first = self.first
+  local last = self.last
+  local i = first
+  local n = 0
+  local f
+
+  f = function()
+    if i > last then
+      return nil
+    end
+    local element = self._e[i]
+    i = i + 1
+    if element ~= REMOVED then
+      n = n + 1
+      return n, element
+    end
+    -- tail call to skip tombbstone
+    return f()
+  end
+
+  return f
+end
+
+--- Return a list/array with the elements of the queue (here head is index 1)
+function Deque:to_array()
+  local r = {}
+  for i, e in self:ipairs() do
+    r[i] = e
+  end
+  return r
+end
+
+return Deque
+
+
+
+

--- a/lua/lib/container/deque_test.lua
+++ b/lua/lib/container/deque_test.lua
@@ -1,0 +1,222 @@
+T = dofile('lib/test/luaunit.lua')
+Deque = dofile('lib/container/deque.lua')
+
+function test_push()
+  local d = Deque.new()
+  d:push('a')
+  T.assertEquals(d._e[d.first], 'a')
+  T.assertEquals(d:count(), 1)
+  d:push('b')
+  T.assertEquals(d._e[d.first], 'b')
+  T.assertEquals(d:count(), 2)
+end
+
+function test_pop()
+  local d = Deque.new()
+  d:push('a')
+  d:push('b')
+  T.assertEquals(d:count(), 2)
+  T.assertEquals(d:pop(), 'b')
+  T.assertEquals(d:count(), 1)
+  T.assertEquals(d:pop(), 'a')
+  T.assertEquals(d:count(), 0)
+end
+
+function test_peek()
+  local d = Deque.new()
+  -- empty case
+  T.assertEquals(d:peek(), nil)
+  T.assertEquals(d:peek(1), nil)
+  T.assertEquals(d:peek(3), nil)
+
+  -- head
+  d:push_back('a')
+  T.assertEquals(d:peek(), 'a')
+  T.assertEquals(d:count(), 1)
+  T.assertEquals(d:peek(2), nil)
+
+  -- tombstone in middle
+  d:push_back('b')
+  d:push_back('c')
+  d:remove('b')
+  T.assertEquals(d:count(), 2)
+  T.assertEquals(d:peek(1), 'a')
+  T.assertEquals(d:peek(2), 'c')
+end
+
+function test_push_back()
+  local d = Deque.new()
+  d:push_back('a')
+  T.assertEquals(d._e[d.last], 'a')
+  T.assertEquals(d:count(), 1)
+  d:push_back('b')
+  T.assertEquals(d._e[d.last], 'b')
+  T.assertEquals(d:count(), 2)
+end
+
+function test_pop_back()
+  local d = Deque.new()
+  d:push('a')
+  d:push('b')
+  T.assertEquals(d:count(), 2)
+  T.assertEquals(d:pop_back(), 'a')
+  T.assertEquals(d:count(), 1)
+  T.assertEquals(d:pop_back(), 'b')
+  T.assertEquals(d:count(), 0)
+end
+
+function test_peek_back()
+  local d = Deque.new()
+  -- empty case
+  T.assertEquals(d:peek_back(), nil)
+  T.assertEquals(d:peek_back(1), nil)
+  T.assertEquals(d:peek_back(3), nil)
+
+  -- head
+  d:push_back('a')
+  T.assertEquals(d:peek_back(), 'a')
+  T.assertEquals(d:count(), 1)
+  T.assertEquals(d:peek_back(2), nil)
+
+  -- tombstone in middle
+  d:push_back('b')
+  d:push_back('c')
+  d:remove('b')
+  T.assertEquals(d:count(), 2)
+  T.assertEquals(d:peek_back(1), 'c')
+  T.assertEquals(d:peek_back(2), 'a')
+end
+
+function test_deque_new_with_elements()
+  local d = Deque.new({'a', 'b', 'c'})
+  T.assertEquals(d._e[d.first], 'a')
+  T.assertEquals(d._e[d.last], 'c')
+end
+
+function test_clear()
+  local d = Deque.new({'a', 'b', 'c'})
+  T.assertEquals(d:count(), 3)
+  d:clear()
+  T.assertEquals(d:count(), 0)
+  T.assertEquals(d:pop(), nil)
+  T.assertEquals(d:pop_back(), nil)
+end
+
+function test_extend_back_with_list()
+  local d = Deque.new()
+  d:extend_back(Deque.new({'a', 'b', 'c'}))
+  T.assertEquals(d:count(), 3)
+  d:extend_back(Deque.new({'z'}))
+  T.assertEquals(d:count(), 4)
+  T.assertEquals(d:pop_back(), 'z')
+  T.assertEquals(d:pop_back(), 'c')
+end
+
+function test_remove_front()
+  local d = Deque.new({'a', 'b', 'c'})
+  T.assertEquals(d:remove('a'), 'a')
+  T.assertEquals(d:count(), 2)
+  T.assertEquals(d:remove('b'), 'b')
+  T.assertEquals(d:count(), 1)
+end
+
+function test_remove_back()
+  local d = Deque.new({'a', 'b', 'c'})
+  T.assertEquals(d:remove('c'), 'c')
+  T.assertEquals(d:count(), 2)
+  T.assertEquals(d:remove('b'), 'b')
+  T.assertEquals(d:count(), 1)
+end
+
+function test_remove_middle()
+  local d = Deque.new({'a', 'b', 'c'})
+  T.assertEquals(d:remove('b'), 'b')
+  T.assertEquals(d:count(), 2)
+  T.assertEquals(d:pop(), 'a')
+  T.assertEquals(d:pop(), 'c')
+  T.assertEquals(d:count(), 0)
+end
+
+function test_remove_with_duplicates_in_middle()
+  local d = Deque.new({'a', 'a', 'b', 'c', 'b'})
+  T.assertEquals(d:remove('a'), 'a')
+  T.assertEquals(d:count(), 4)
+  T.assertEquals(d:remove('b'), 'b')
+  T.assertEquals(d:remove('b'), 'b')
+  T.assertEquals(d:count(), 2)
+  T.assertEquals(d:pop(), 'a')
+  T.assertEquals(d:pop(), 'c')
+end
+
+local function match_note_event(a, b)
+  return (a.ch == b.ch) and (a.note == b.note)
+end
+
+function test_remove_with_predicate()
+  local na = { ch = 1, note = 30 }
+  local nb = { ch = 1, note = 40 }
+  local nc = { ch = 1, note = 50 }
+
+  local d = Deque.new({ na, nb, nc })
+  -- remove, matching front
+  T.assertEquals(d:remove(na, match_note_event), na)
+  -- remove, matching back
+  d:push_back(na)
+  T.assertEquals(d:remove(na, match_note_event), na)
+  T.assertEquals(d:to_array(), { nb, nc })
+
+  -- remove, matching middle
+  d:push(na)
+  T.assertEquals(d:remove(nb, match_note_event), nb)
+  T.assertEquals(d:to_array(), { na, nc })
+end
+
+function test_contains()
+  local d = Deque.new({'a', 'b', 'c'})
+  T.assertTrue(d:contains('a'))
+  T.assertTrue(d:contains('c'))
+  T.assertTrue(d:contains('b'))
+  T.assertFalse(d:contains('missing'))
+  local thing = d:pop()
+  T.assertFalse(d:contains(thing))
+end
+
+function test_contains_with_predicate()
+  local na = { ch = 1, note = 30 }
+  local nb = { ch = 1, note = 40 }
+  local nc = { ch = 1, note = 50 }
+
+  local d = Deque.new({ na, nb, nc })
+  T.assertTrue(d:contains(na, match_note_event))
+  T.assertFalse(d:contains({ ch = 2, note = 2 }))
+end
+
+function test_iter_empty()
+  local d = Deque.new()
+  for i, v in d:ipairs() do
+    T.assertTrue(false) -- shouldn't get here
+  end
+end
+
+function test_iter_simple()
+  local v = {'a', 'b', 'c'}
+  local d = Deque.new(v)
+  T.assertEquals(d:to_array(), v)
+end
+
+function test_iter_after_pop()
+  local d = Deque.new({'a', 'b', 'c'})
+  d:pop()
+  T.assertEquals(d:to_array(), {'b', 'c'})
+  d:pop_back()
+  T.assertEquals(d:to_array(), {'b'})
+end
+
+function test_iter_after_remove()
+  local d = Deque.new({'a', 'b', 'b', 'c'})
+  d:remove('b')
+  d:remove('b')
+  T.assertEquals(d:to_array(), {'a', 'c'})
+end
+
+os.exit(T.LuaUnit.run())

--- a/lua/lib/container/observable.lua
+++ b/lua/lib/container/observable.lua
@@ -1,0 +1,97 @@
+-- observable - an observable value
+-- @module observable
+-- @alias Observable
+
+local WeakTable = require 'container/weaktable'
+
+--
+-- reference: https://en.wikipedia.org/wiki/Observer_pattern)
+--
+
+local Observable = {}
+Observable.__index = Observable
+
+--- Create an Observable value (object).
+--
+-- An observable value notifies registered observers each time the value is set.
+--
+-- @tparam anything initial Initial value, defaults to nil
+-- @treturn Observable instance.
+function Observable.new(initial)
+  local o = {}
+  o._observers = WeakTable.new()
+  o._value = initial
+  setmetatable(o, Observable)
+  return o
+end
+
+function Observable:__newindex()
+  error("Use the set() method to change the observable value")
+end
+
+--- Set the value
+-- @tparam anything value New value for observable.
+-- @tparam boolean quiet If true, do not notify observers.
+function Observable:set(value, quiet)
+  -- use rawset to avoid __newindex if initial value of _value is nil
+  rawset(self, '_value', value)
+  if not quiet then
+    self:notify_observers()
+  end
+end
+
+--- Return the current value (short hand for the 'value' method)
+-- @treturn anything
+function Observable:__call()
+  return self._value
+end
+
+--- Return the current value
+-- @treturn anything
+function Observable:value()
+  return self._value
+end
+
+--- Register an observer of value changes
+--
+-- An observer is identified by a key which can be any type (number, string,
+-- table, etc). Registering an observer replaces any previous registration
+-- associated with that key.
+--
+-- The handler is a function which is passed one argument, the new value. If
+-- `handler` is not provided it is assumed that the `observer` is an object with
+-- a `notify` method and the `notify` method is called with the new value.
+--
+-- @tparam anything observer Identity of observer.
+-- @tparam function handler New value callback, optional.
+function Observable:register(observer, handler)
+  if handler ~= nil then
+    self._observers[observer] = handler
+  else
+    self._observers[observer] = function(value)
+      observer:notify(value)
+    end
+  end
+end
+
+--- Unregister an observer of value changes
+-- @tparam anything observer Identity of observer.
+-- @treturn boolean true if the observer was known and unregistered.
+function Observable:unregister(observer)
+  local existing = self._observers[observer]
+  if existing ~= nil then
+    self._observers[observer] = nil
+    return true
+  end
+  return false
+end
+
+--- Notify registered observers of current value (normally called by `set`).
+function Observable:notify_observers()
+  for o, f in pairs(self._observers) do
+    -- TODO: determine whether this really should be a pcall or not
+    pcall(f, self._value)
+  end
+end
+
+return Observable

--- a/lua/lib/container/observable_test.lua
+++ b/lua/lib/container/observable_test.lua
@@ -1,0 +1,132 @@
+T = require 'test/luaunit'
+Observable = dofile('lib/container/observable.lua')
+
+--
+-- Trivial "observer"
+--
+local Watcher = {}
+Watcher.__index = Watcher
+
+function Watcher.new()
+  local o = setmetatable({}, Watcher)
+  o.value = nil
+  o.notify_count = 0
+  return o
+end
+
+function Watcher:notify(value)
+  self.value = value
+  self.notify_count = self.notify_count + 1
+end
+
+--
+-- tests
+--
+
+function test_new_and_value()
+  T.assertNil(Observable.new():value())
+  T.assertEquals(Observable.new(3):value(), 3)
+  local foo = {"one", "two"}
+  T.assertEquals(Observable.new(foo):value(), foo)
+end
+
+function test_call()
+  T.assertNil(Observable.new()())
+  T.assertEquals(Observable.new(3)(), 3)
+  local bar = {"bar", "baz"}
+  T.assertEquals(Observable.new(bar)(), bar)
+end
+
+function test_set_no_observers()
+  local o = Observable.new(3)
+  o:set(4)
+  T.assertEquals(o(), 4)
+end
+
+function test_set_with_observers()
+  local w1 = Watcher.new()
+  local w2 = Watcher.new()
+  local o = Observable.new(3)
+  o:register(w1)
+  o:register(w2)
+  local v = 1234
+  o:set(v)
+  T.assertEquals(w1.value, v)
+  T.assertEquals(w2.value, v)
+end
+
+function test_setting_new_fields_is_error()
+  local o = Observable.new("foo")
+  T.assertError(function() o.bad = 3 end)
+  T.assertError(function() o["foo"] = "bar" end)
+end
+
+function test_no_double_registration()
+  local w = Watcher.new()
+  local o = Observable.new()
+  o:register(w)
+  o:register(w)
+  o:set("foo")
+  T.assertEquals(w.value, "foo")
+  T.assertEquals(w.notify_count, 1)
+end
+
+function test_registration_with_callback()
+  local count = 0
+  local value = 0
+  local handler = function(v)
+    count = count + 1
+    value = v
+  end
+  local observer = "foo"  -- any value key
+
+  local o = Observable.new()
+  o:register(observer, handler)
+  o:register(observer, handler)
+  o:set("bar")
+  T.assertEquals(count, 1)
+  T.assertEquals(value, "bar")
+end
+
+function test_unregister()
+  local count = 0
+  local value = 0
+  local handler = function(v)
+    count = count + 1
+    value = v
+  end
+  local observer = "bar"  -- any value key
+  local w = Watcher.new()
+
+  local o = Observable.new()
+  o:register(observer, handler)
+  o:register(w)
+  o:set(-23)
+
+  -- confirm callback notification
+  T.assertEquals(count, 1)
+  T.assertEquals(value, -23)
+
+  -- confirm method notification
+  T.assertEquals(w.notify_count, 1)
+  T.assertEquals(w.value, -23)
+
+  T.assertTrue(o:unregister(w))
+  T.assertTrue(o:unregister(observer))
+
+  -- confirm notification stopped (previous values are the same)
+  o:set(17)
+  T.assertEquals(count, 1)
+  T.assertEquals(value, -23)
+  T.assertEquals(w.notify_count, 1)
+  T.assertEquals(w.value, -23)
+end
+
+function test_unregister_of_unknown_observer()
+  local w = Watcher.new()
+  local o = Observable.new()
+  T.assertFalse(o:unregister("foo"))
+  T.assertFalse(o:unregister(w))
+end
+
+os.exit(T.LuaUnit.run())

--- a/lua/lib/container/watchtable.lua
+++ b/lua/lib/container/watchtable.lua
@@ -1,0 +1,33 @@
+-- WatchTable - a table which can be watched of key changes
+-- @module WatchTable
+-- @alias WatchTable
+
+local WatchTable = {}
+WatchTable.__index = WatchTable
+
+--- Create a table which invokes a callback each time a value is set.
+--
+-- The callback function is passed the key, value after a given set operation
+-- has been performed.
+--
+-- @tparam table t Initial table contents (can be nil).
+-- @tparam function cb Callback on key set
+-- @treturn table
+function WatchTable.new(t, cb)
+  local o = {}
+  o.table = t or {}
+  o.callback = cb or function(...) end
+  setmetatable(o, WatchTable)
+  return o
+end
+
+function WatchTable:__newindex(k, v)
+  rawset(self.table, k, v)
+  self.callback(k, v)
+end
+
+function WatchTable:__index(k)
+  return self.table[k]
+end
+
+return WatchTable

--- a/lua/lib/container/weaktable.lua
+++ b/lua/lib/container/weaktable.lua
@@ -1,0 +1,21 @@
+-- weaktable - a table with weakly held keys
+-- @module weaktable
+-- @alias WeakTable
+
+local WeakTable = {}
+WeakTable.__index = WeakTable
+WeakTable.__mode = "k"  --  invoke dark magic: https://www.lua.org/pil/17.html
+
+--- Create a table with weakly held keys
+--
+-- A table with weakly held keys allows objects to be used as keys within the
+-- table but it won't prevent those objects from being garbage collected
+--
+-- @tparam table initial Initial table contents, optional.
+-- @treturn table
+function WeakTable.new(t)
+  local t = setmetatable(t or {}, WeakTable)
+  return t
+end
+
+return WeakTable

--- a/lua/lib/elca.lua
+++ b/lua/lib/elca.lua
@@ -1,0 +1,113 @@
+--- elementary cellular automata
+-- @module lib.elca
+
+local CA = {}
+
+CA.__index = CA
+
+CA.NUM_STATES = 128
+CA.BOUND_LOW = 0
+CA.BOUND_HIGH = 1
+CA.BOUND_WRAP = 2
+
+--- constructor
+-- @treturn elca
+function CA.new()
+   local ca = setmetatable({}, CA)
+   
+    ca.state = {}
+    for i=1,CA.NUM_STATES do
+       ca.state[i] = 0
+    end
+    
+    ca.bound_mode_l = CA.BOUND_LOW
+    ca.bound_mode_r = CA.BOUND_LOW
+    ca.bound_l = 1
+    ca.bound_r = 128
+    
+    ca.rule = 34
+    ca.offset = 0
+    return ca
+end 
+
+--- update all state
+function CA:update() 
+   local newState = {}
+   for i=1,CA.NUM_STATES do
+      local l, c, r = self:neighbors(i)
+      local code = CA.code(l, c, r)
+      if (self.rule & (1 << code)) > 0 then newState[i] = 1
+      else newState[i] = 0 end
+   end
+   self.state = newState
+end
+
+--- helper: return three values to use for neighbor code
+-- @tparam number i
+-- @return tuple of left, right, center
+function CA:neighbors(i)
+   local l
+   local r
+
+   if i <= self.bound_l then
+      if self.bound_mode_l == CA.BOUND_LOW then l = 0
+      elseif self.bound_mode_l == CA.BOUND_HIGH then l = 1 
+      else l = self.state[self.bound_r] end
+   else
+      l = self.state[i-1]
+   end
+   
+   -- right neighbor
+   if i >= CA.NUM_STATES then
+      if self.bound_mode_r == CA.BOUND_LOW then r = 0
+      elseif self.bound_mode_r == CA.BOUND_HIGH then r = 1 
+      else r = self.state[self.bound_l] end
+   else
+      r = self.state[i+1]
+   end
+   
+--   print("get_neighbors ", i, ":", l, self.state[i], r)
+   return l, self.state[i], r
+end
+
+--- get binary code for value given cell and neighbors
+-- @tparam number l left cell
+-- @tparam number c center cell
+-- @tparam number r right cell
+function CA.code(l, c, r)
+   local n = 0
+   if l > 0 then n = n | 4 end
+   if c > 0 then n = n | 2 end   
+   if r > 0 then n = n | 1 end
+   return n
+end
+
+--- return 8 cells at current offset
+-- @tparam number n
+-- @treturn table table with 8 binary values
+function CA:window(n)
+   if n == nil then n = CA.NUM_STATES end
+   local w = {}
+   for i=1,n do
+      w[i] = self.state[i + self.offset]
+   end
+   return w
+end 
+
+--- change current state at index,
+--- and update the rule to that which would have produced the new state
+function CA:set_rule_by_state(val, l, c, r)
+   local code = CA.code(l, c, r)
+   print("code: ", code)
+   if val > 0 then self.rule = self.rule | (1<<code)
+   else self.rule = self.rule & (~(1<<code)) end
+end
+
+--- clear all states
+function CA:clear()
+   for i=1,CA.NUM_STATES do self.state[i] = 0 end
+end
+
+-- TODO: maybe setter methods that clamp stuff
+
+return CA

--- a/lua/lib/er.lua
+++ b/lua/lib/er.lua
@@ -1,0 +1,35 @@
+--- Euclidean rhythm (http://en.wikipedia.org/wiki/Euclidean_Rhythm)
+-- @module lib.er
+
+er = {}
+--- gen
+-- @tparam number k : number of pulses
+-- @tparam number n : total number of steps
+-- @tparam number w : shift amount
+-- @treturn table
+function er.gen(k, n, w)
+   w = w or 0
+   -- results array, intially all zero
+   local r = {}
+   for i=1,n do r[i] = false end
+
+   if k<1 then return r end
+
+   -- using the "bucket method"
+   -- for each step in the output, add K to the bucket.
+   -- if the bucket overflows, this step contains a pulse.
+   local b = n
+   for i=1,n do
+      if b >= n then
+         b = b - n
+         local j = i + w
+         while (j > n) do j = j - n end
+         while (j < 1) do j = j + n end
+         r[j] = true
+      end
+      b = b + k
+   end
+   return r
+end
+
+return er

--- a/lua/lib/filters.lua
+++ b/lua/lib/filters.lua
@@ -1,0 +1,233 @@
+--- Filters
+--- @module lib.filters
+--
+-- some filters that could be useful for musical event processing
+
+local f = {}
+f.__index = f
+
+-- helper to increment and wrap an index
+local function wrap_inc(x, max)
+   local y = x + 1
+   while y > max do y = y - max end
+   return y
+end
+
+--- clear a filter's history
+function f:clear()
+   for i=1,self.bufsize do
+      self.buf[i]=0
+   end
+end
+
+-- debug function to print the buffer
+function f:__tostring()
+   str = ''
+   for i=1,self.bufsize do
+      str = str .. self.buf[i] .. ', '
+   end
+   return str
+end
+
+----------------------
+--- @type filters.mean
+-- moving, windowed mean-average filter
+
+local mean = {}
+mean.__index = mean
+setmetatable(mean, { __index=f })
+
+-------------------------------------------------------------
+--- constructor
+--- @param bufsize window size, cannot change after creation
+function mean.new(bufsize)
+   local new = setmetatable({}, mean)
+
+   new.buf = {}
+   if bufsize==nil then bufsize=16 end
+   new.bufsize = bufsize
+   new.scale = 1/bufsize
+   new:clear()
+
+   new.pos = 1
+--   new.tail = 2
+   new.sum = 0
+
+   print('done allocating new mean filter')
+   return new
+end
+
+--- process a new input value and update the average
+-- @param x new input
+-- @return scaled sum of stored history
+function mean:next(x)
+   local a = x*self.scale
+   self.sum = self.sum + a
+   self.sum = self.sum - self.buf[self.pos]
+   self.buf[self.pos] = a
+   self.pos = wrap_inc(self.pos, self.bufsize)
+   return self.sum
+end
+
+----------------------
+--- @type filters.median
+--- moving, windowed median average filter
+
+local median = {}
+median.__index = median
+setmetatable(median, { __index=f })
+
+--- constructor
+--- @param bufsize window size, cannot change after creation
+function median.new(bufsize)
+   local new = setmetatable({}, median)
+
+   new.buf = {}
+   if bufsize==nil then bufsize=17 end
+   -- only odd buffer sizes are allowed!
+   if (bufsize%2) == 0 then bufsize = bufsize + 1 end
+   new.bufsize = bufsize
+   new.midpoint = (bufsize-1)/2
+   new:clear()
+
+   new.value = 0
+   new.pos = 1
+   return new
+end
+
+-- count how many values in buffer are below current median
+function median:count_below()
+   local count = 0
+   local max = -math.huge
+   local x
+   for i=1,self.bufsize do
+      x = self.buf[i]
+      if x < self.value then count = count + 1 end
+      if x > max then max = x end
+   end
+   return count, max
+end
+function median:count_above()
+   local count = 0
+   local min = math.huge
+   local x
+   for i=1,self.bufsize do
+      x = self.buf[i]
+      if x > self.value then count = count + 1 end
+      if x < min then min = x end
+   end
+   return count, min
+end
+
+
+--- process a new input value and update the average
+-- @param x new input
+-- @return median of last N values
+function median:next(x)
+   -- save the oldest value, overwrite with newest value
+   local x0 = self.buf[self.pos]
+   self.buf[self.pos] = x
+   self.pos = wrap_inc(self.pos, self.bufsize)
+   if x > self.value and x0 <= self.value then
+      local count, min = self:count_above()
+      if count > self.midpoint then
+	 self.value = min
+      end
+   end
+   if x < self.value and x0 >= self.value then
+      local count, max = self:count_below()
+      if count > self.midpoint then
+	 self.value = max
+      end
+   end
+   return self.value
+end
+
+----------------------
+--- @type filters.smoother
+-- simple one-pole lowpass smoothing filter
+
+local smoother = {}
+smoother.__index = smoother
+setmetatable(smoother, {__index=f})
+
+--------
+-- constructor
+-- @param time -60db convergence time
+-- @param sr expected sample rate
+function smoother.new(time, sr)
+   local new = setmetatable({}, smoother)
+   new.buf = {}
+   new.bufsize = 1
+   new:clear()
+   new.x = 0
+   new.a = 1
+   new.sr = sr
+   new.t = time
+   new:calc_coeff()
+   new.pos = 1 -- NB: not really used
+   return new
+end
+
+
+function smoother:calc_coeff()
+   self.a = 1 - math.exp(-6.9 / (self.t * self.sr))
+end
+
+-- set convergence time
+-- @param t time to converge within -60db of target
+function smoother:set_time(t)
+   self.t = t
+   self:calc_coeff()
+end
+
+-- set samplerate
+-- @param sr new sample rate
+function smoother:set_sr(sr)
+   self.sr = sr
+   self:calc_coeff()
+end
+
+smoother.EPSILON = 1e-8
+
+-- calculate the next sample based on new input
+-- @param x new input (optional)
+-- @return smoothed output
+function smoother:next(x)
+   if x == nil then x = self.x
+   else self.x = x end
+
+   local d =  x - self.buf[1]
+
+   if math.abs(d) < smoother.EPSILON then
+      self.buf[1] = x
+   else
+      self.buf[1] = self.buf[1] + (self.a * d)
+   end
+   return self.buf[1]
+end
+
+-- immediately jump to a new value
+-- @param new value
+function smoother:set_value(x)
+   self.buf[1] = x
+end
+
+-- set target without updating
+-- @param new target
+function smoother:set_target(x)
+   self.x = x
+end
+
+-----------------------------------
+-- TODO: what else would be useful?
+--
+--- quantile estimator?
+--- constant time ramp?
+--- some kind of hysteresis / latching?
+
+f.mean = mean
+f.median = median
+f.smoother = smoother
+
+return f

--- a/lua/lib/formatters.lua
+++ b/lua/lib/formatters.lua
@@ -1,0 +1,209 @@
+--- Formatters
+-- @module lib.formatters
+local Formatters = {}
+
+local function format(param, value, units)
+  return value.." "..(units or param.controlspec.units or "")
+end
+
+
+-- Raw
+
+--- format_freq_raw
+-- @param freq
+function Formatters.format_freq_raw(freq)
+  if freq < 0.1 then
+    freq = util.round(freq, 0.001) .. " Hz"
+  elseif freq < 100 then
+    freq = util.round(freq, 0.01) .. " Hz"
+  elseif util.round(freq, 1) < 1000 then
+    freq = util.round(freq, 1) .. " Hz"
+  else
+    freq = util.round(freq / 1000, 0.01) .. " kHz"
+  end
+  return freq
+end
+
+--- format_secs_raw
+-- @param secs
+function Formatters.format_secs_raw(secs)
+  local out_string
+  if secs > 3600 then
+    out_string = util.round(secs / 60 / 60, 0.1) .. " h"
+  elseif secs >= 120 then
+    out_string = util.round(secs / 60, 0.1) .. " min"
+  elseif secs >= 60 then
+    out_string = util.round(secs) .. " s"
+  elseif util.round(secs, 0.01) >= 1 then
+    out_string = util.round(secs, 0.1) .. " s"
+  else
+    out_string = util.round(secs, 0.01)
+    if string.len(out_string) < 4 then out_string = out_string .. "0" end
+    out_string = out_string .. " s"
+  end
+  return out_string
+end
+
+
+-- Params
+
+--- default
+-- @param param
+function Formatters.default(param)
+  return Formatters.round(0.01)(param)
+end
+
+--- percentage
+-- @param param
+function Formatters.percentage(param)
+  return format(param, util.round(param:get()*100), "%")
+end
+
+--- unipolar_as_percentage
+-- @param param
+function Formatters.unipolar_as_percentage(param)
+  return format(param, util.round(param:get()*100), "%")
+end
+
+--- bipolar_as_percentage
+-- @param param
+function Formatters.bipolar_as_percentage(param)
+  return format(param, util.round(param:get()*100), "%")
+end
+
+--- secs_as_ms
+-- @param param
+function Formatters.secs_as_ms(param)
+  return format(param, util.round(param:get()*1000), "ms")
+end
+
+--- unipolar_as_true_false
+-- @param param
+function Formatters.unipolar_as_true_false(param)
+  local str
+  if param:get() == 1 then str = "true" else str = "false" end
+  return format(param, str)
+end
+
+--- unipolar_as_enabled_disabled
+-- @param param
+function Formatters.unipolar_as_enabled_disabled(param)
+  local str
+  if param:get() == 1 then str = "enabled" else str = "disabled" end
+  return format(param, str)
+end
+
+--- bipolar_as_pan_widget
+-- @param param
+function Formatters.bipolar_as_pan_widget(param)
+  local dots_per_side = 10
+  local widget
+  local function add_dots(num_dots)
+    for i=1,num_dots do widget = (widget or "").."." end
+  end
+  local function add_bar()
+    widget = (widget or "").."|"
+  end
+
+  local value = param:get()
+  local pan_side = math.abs(value)
+  local pan_side_percentage = util.round(pan_side*100)
+  local descr
+  local dots_left
+  local dots_right
+
+  if value > 0 then
+    dots_left = dots_per_side+util.round(pan_side*dots_per_side)
+    dots_right = util.round((1-pan_side)*dots_per_side)
+    if pan_side_percentage >= 1 then
+      descr = "R"..pan_side_percentage
+    end
+  elseif value < 0 then
+    dots_left = util.round((1-pan_side)*dots_per_side)
+    dots_right = dots_per_side+util.round(pan_side*dots_per_side)
+    if pan_side_percentage >= 1 then
+     descr = "L"..pan_side_percentage
+    end
+  else
+    dots_left = dots_per_side
+    dots_right = dots_per_side
+  end
+
+  if descr == nil then
+    descr = "MID"
+  end
+
+  add_bar()
+  add_dots(dots_left)
+  add_bar()
+  add_dots(dots_right)
+  add_bar()
+
+  return format(param, descr.." "..widget, "")
+end
+
+--- unipolar_as_multimode_filter_freq
+-- @param param
+function Formatters.unipolar_as_multimode_filter_freq(param)
+  local chars = 20
+  local widget
+  local function add_dots(num) -- TODO: refactor out
+    for i=1,num do widget = (widget or "").."." end
+  end
+  local function add_bars(num) -- TODO: refactor out
+    for i=1,num do widget = (widget or "").."|" end
+  end
+
+  local value = ControlSpec.BIPOLAR:map(param:get())
+  local abs_mapped_value = math.abs(value)
+  local percentage = util.round(abs_mapped_value*100)
+  local descr
+
+  if value > 0 then
+    local clear = value*chars
+    if percentage >= 1 then
+      descr = "HP"..percentage
+    end
+    add_bars(1)
+    add_dots(clear)
+    add_bars(chars-clear+1)
+  elseif value < 0 then
+    local fill = (value+1)*chars
+    if percentage >= 1 then
+      descr = "LP"..(100-percentage)
+    end
+    add_bars(fill+1)
+    add_dots(chars-fill)
+    add_bars(1)
+  else
+    add_bars(chars+2)
+  end
+
+  if descr == nil then
+    descr = "OFF"
+  end
+
+  return format(param, widget.." "..descr, "")
+end
+
+--- round
+-- @param precision
+function Formatters.round(precision)
+  return function(param)
+    return format(param, util.round(param:get(), precision))
+  end
+end
+
+--- format_freq
+-- @param param
+function Formatters.format_freq(param)
+  return Formatters.format_freq_raw(param:get())
+end
+
+--- format_secs
+-- @param param
+function Formatters.format_secs(param)
+  return Formatters.format_secs_raw(param:get())
+end
+
+return Formatters

--- a/lua/lib/gridbuf.lua
+++ b/lua/lib/gridbuf.lua
@@ -1,0 +1,98 @@
+local function clamp(value, min, max)
+  return math.min(max, (math.max(value, min)))
+end
+
+local function grid_binary_op(op, lhs, rhs)
+  local result = { grid = {}, width = lhs.width, height = lhs.height }
+
+  for row = 1, lhs.height do
+    result.grid[row] = {}
+    for col = 1, lhs.width do
+      result.grid[row][col] = clamp(op(lhs.grid[row][col], rhs.grid[row][col]), 0, 15)
+    end
+  end
+
+  setmetatable(result, getmetatable(lhs))
+  return result
+end
+
+local Buffer = {
+  __add = function(lhs, rhs)
+    return grid_binary_op(function(a, b) return a + b end, lhs, rhs)
+  end,
+  __sub = function(lhs, rhs)
+    return grid_binary_op(function(a, b) return a - b end, lhs, rhs)
+  end,
+  __bor = function(lhs, rhs)
+    return grid_binary_op(function(a, b) return math.max(a, b) end, lhs, rhs)
+  end,
+  __bxor = function(lhs, rhs)
+    return grid_binary_op(function(a, b) return a ~ b end, lhs, rhs)
+  end,
+}
+Buffer.__index = Buffer
+
+function Buffer.new(w, h)
+  local b = {}
+  setmetatable(b, Buffer)
+
+  b.grid = {}
+  b.width = w
+  b.height = h
+
+  for row = 1, h do
+    b.grid[row] = {}
+    for col = 1, w do
+      b.grid[row][col] = 0
+    end
+  end
+
+  return b
+end
+
+function Buffer:led_level_set(x, y, l)
+  self.grid[y][x] = clamp(l, 0, 15)
+end
+
+function Buffer:led_level_row(x_offset, y, data)
+  for i, l in ipairs(data) do
+    self:led_level_set(x_offset + i - 1, y, data[i])
+  end
+end
+
+function Buffer:led_level_col(x, y_offset, data)
+  for i, l in ipairs(data) do
+    self:led_level_set(x, y_offset + i - 1, data[i])
+  end
+end
+
+function Buffer:led_level_all(l)
+  for row = 1, self.height do
+    for col = 1, self.width do
+      self.grid[row][col] = l
+    end
+  end
+end
+
+function Buffer:render(grid)
+  -- TODO: use map when it's available
+  for row = 1, self.height do
+    for col = 1, self.width do
+      grid:led(col, row, self.grid[row][col])
+    end
+  end
+end
+
+function Buffer:print()
+  for row = 1, self.height do
+    local format = ""
+    local values = {}
+    for col = 1, self.width do
+      format = format.."%01x"
+      values[col] = self.grid[row][col]
+    end
+    print(string.format(format, table.unpack(values)))
+  end
+end
+
+return Buffer

--- a/lua/lib/intonation.lua
+++ b/lua/lib/intonation.lua
@@ -1,0 +1,297 @@
+--- "just" some intonation tables
+-- @module lib.intonation
+-- @alias JI
+
+local JI = {}
+
+--- 12-tone scales
+-- @section 12-tone
+
+--- small variation of ptolemaic 5-limit with closer minor 7th.
+-- taking cue from jeff snyder and calling this "normal" since it is most commonly used.
+-- also known as "Duodene" by Alexander Ellis (19th c.)
+-- @treturn table
+function JI.normal() 
+   return { 
+      1/1, 16/15, 9/8, 6/5, 5/4, 4/3, 45/32, 3/2, 8/5, 5/3, 16/9, 15/8
+   }
+end
+
+
+--- ptolemaic 12-tone (5-limit) - very similar except for kinda weird m7
+-- @treturn table
+function JI.ptolemy() 
+   return { 
+      1/1, 16/15, 9/8, 6/5, 5/4, 4/3, 45/32, 3/2, 8/5, 5/3, 9/5, 15/8
+   }
+end
+
+--- ben johnston's overtone scale
+-- identical to jeff snyder's "otonal" scale
+-- @treturn table
+function JI.overtone() 
+   return {
+      1/1, 17/16, 9/8, 19/16, 5/4, 21/16, 11/8, 3/2, 13/8, 27/16, 7/4, 15/8
+   }
+end
+
+--- subharmonic mirror of the overtone scale
+-- jeff calls this "utonal" after partch
+-- @treturn table
+function JI.undertone()
+   return { 
+      1/1, 16/15, 8/7, 32/27, 16/13, 4/3, 16/11, 32/21, 8/5, 32/19, 16/9, 32/17,
+   }
+end
+
+--- lamonte young's 'well-tuned piano' (very eccentric)
+-- @treturn table
+function JI.lamonte() 
+   return {
+      1/1, 567/512, 9/8, 147/128, 1323/1024, 21/16,  189/128, 3/2, 49/32,  441/256, 7/4,63/32
+   }
+end
+
+
+
+--- higher-tone scales / gamuts
+-- @section higher-tone
+
+--- gioseffo zarlino's 16-tone (5-limit)
+-- @treturn table
+function JI.zarlino() 
+   return {
+      1/1, 25/24, 10/9, 9/8, 32/27, 6/5, 5/4, 4/3, 25/18, 45/32, 3/2, 25/16, 5/3, 16/9, 9/5, 15/8
+   }
+end
+
+
+--- harry partch 43-tone (11-limit, plus some)
+-- @treturn table
+function JI.partch() 
+   return {
+      1/1, 
+      81/80, 
+      33/32, 
+      21/20, 
+      16/15, 
+      12/11, 
+      11/10, 
+      10/9, 
+      9/8, 
+      8/7, 
+      7/6, 
+      32/27, 
+      6/5, 
+      11/9, 
+      5/4, 
+      14/11, 
+      9/7, 
+      21/16, 
+      4/3, 
+      27/20, 
+      11/8, 
+      7/5, 
+      10/7, 
+      16/11, 
+      40/27, 
+      3/2, 
+      32/21, 
+      14/9, 
+      11/7, 
+      8/5, 
+      18/11, 
+      5/3, 
+      27/16, 
+      12/7, 
+      7/4, 
+      16/9, 
+      9/5, 
+      20/11, 
+      11/6, 
+      15/8, 
+      40/21, 
+      64/33, 
+      160/81
+   }
+end
+
+--- finally, jeff snyder's full 168-tone gamut
+-- see his disseration for reference:
+-- http://scatter.server295.com/full-dissertation.pdf
+-- @treturn table
+
+function JI.gamut()
+   return {
+      1/1 ,
+      256/255,
+      96/95,
+      81/80,
+      65/64,
+      64/63,
+      45/44,
+      40/39,
+      33/32,
+      25/24,
+      21/20,
+      20/19,
+      256/243,
+      135/128,
+      19/18,
+      18/17,
+      17/16,
+      16/15,
+      15/14,
+      13/12,
+      12/11,
+      35/32,
+      128/117,
+      11/10,
+      10/9,
+      285/256,
+      64/57,
+      9/8,
+      96/85,
+      17/15,
+      256/225,
+      585/512,
+      8/7,
+      55/48,
+      15/13,
+      64/55,
+      7/6,
+      75/64,
+      20/17,
+      45/38,
+      32/27,
+      1215/1024,
+      19/16,
+      153/128,
+      6/5,
+      40/33,
+      39/32,
+      128/105,
+      11/9,
+      315/256,
+      16/13,
+      5/4,
+      64/51,
+      24/19,
+      512/405,
+      81/64,
+      19/15,
+      80/63,
+      51/40,
+      32/25,
+      9/7,
+      165/128,
+      128/99,
+      13/10,
+      21/16,
+      256/195,
+      675/512,
+      45/34,
+      85/64,
+      4/3,
+      171/128,
+      128/95,
+      27/20,
+      65/48,
+      256/189,
+      15/11,
+      48/35,
+      11/8,
+      18/13,
+      25/18,
+      7/5,
+      80/57,
+      45/32,
+      24/17,
+      17/12,
+      64/45,
+      57/40,
+      10/7,
+      36/25,
+      13/9,
+      16/11,
+      35/24,
+      22/15,
+      189/128,
+      96/65,
+      40/27,
+      95/64,
+      765/512,
+      256/171,
+      3/2,
+      128/85,
+      195/128,
+      32/21,
+      20/13,
+      99/64,
+      256/165,
+      14/9,
+      25/16,
+      80/51,
+      63/40,
+      30/19,
+      128/81,
+      405/256,
+      19/12,
+      51/32,
+      8/5,
+      45/28,
+      13/8,
+      512/315,
+      18/11,
+      105/64,
+      64/39,
+      33/20,
+      5/3,
+      855/512,
+      256/153,
+      32/19,
+      27/16,
+      17/10,
+      128/75,
+      12/7,
+      55/32,
+      45/26,
+      26/15,
+      96/55,
+      7/4,
+      225/128,
+      30/17,
+      85/48,
+      16/9,
+      57/32,
+      512/285,
+      9/5,
+      20/11,
+      117/64,
+      64/35,
+      11/6,
+      945/512,
+      24/13,
+      28/15,
+      15/8,
+      32/17,
+      17/9,
+      36/19,
+      256/135,
+      243/128,
+      19/10,
+      40/21,
+      48/25,
+      495/256,
+      64/33,
+      39/20,
+      63/32,
+      128/65,
+      160/81,
+      2025/1024,
+      95/48,
+      255/128
+   }
+end
+
+return JI

--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -1,0 +1,235 @@
+---- module for creating a lattice of sprockets based on a single fast "superclock"
+--
+-- @module Lattice
+-- @release v2.0
+-- @author tyleretters & ezra & zack & rylee
+
+local Lattice, Sprocket = {}, {}
+
+--- instantiate a new lattice
+-- @tparam[opt] table args optional named attributes are:
+-- - "auto" (boolean) turn off "auto" pulses from the norns clock, defaults to true
+-- - "ppqn" (number) the number of pulses per quarter cycle of this superclock, defaults to 96
+-- @treturn table a new lattice
+function Lattice:new(args)
+  local l = setmetatable({}, { __index = Lattice })
+  args = args == nil and {} or args
+  l.auto = args.auto == nil and true or args.auto
+  l.ppqn = args.ppqn == nil and 96 or args.ppqn
+  l.enabled = false
+  l.transport = 0
+  l.superclock_id = nil
+  l.sprocket_id_counter = 100
+  l.sprockets = {}
+  l.sprocket_ordering = {{}, {}, {}, {}, {}}
+  return l
+end
+
+--- start running the lattice
+function Lattice:start()
+  self.enabled = true
+  if self.auto and self.superclock_id == nil then
+    self.superclock_id = clock.run(self.auto_pulse, self)
+  end
+end
+
+--- reset the norns clock without restarting lattice
+function Lattice:reset()
+  -- destroy clock, but not the sprockets
+  self:stop()
+  if self.superclock_id ~= nil then
+    clock.cancel(self.superclock_id)
+    self.superclock_id = nil
+  end
+  for i, sprocket in pairs(self.sprockets) do
+    sprocket.phase = sprocket.division * self.ppqn * 4 * (1 - sprocket.delay) -- "4" because in music a "quarter note" == "1/4"
+    sprocket.downbeat = false
+  end
+  self.transport = 0
+  params:set("clock_reset", 1)
+end
+
+--- reset the norns clock and restart lattice
+function Lattice:hard_restart()
+  self:reset()
+  self:start()
+end
+
+--- stop the lattice
+function Lattice:stop()
+  self.enabled = false
+end
+
+--- toggle the lattice
+function Lattice:toggle()
+  self.enabled = not self.enabled
+end
+
+--- destroy the lattice
+function Lattice:destroy()
+  self:stop()
+  if self.superclock_id ~= nil then
+    clock.cancel(self.superclock_id)
+  end
+  self.sprockets = {}
+  self.sprocket_ordering = {}
+end
+
+--- set_meter is deprecated
+function Lattice:set_meter(_)
+  print("meter is deprecated")
+end
+
+--- use the norns clock to pulse
+-- @tparam table s this lattice
+function Lattice.auto_pulse(s)
+  while true do
+    s:pulse()
+    clock.sync(1/s.ppqn)
+  end
+end
+
+--- advance all sprockets in this lattice a single by pulse, call this manually if lattice.auto = false
+function Lattice:pulse()
+  if self.enabled then
+    local ppc = self.ppqn * 4 -- pulses per cycle; "4" because in music a "quarter note" == "1/4"
+    local flagged=false
+    for i = 1, 5 do
+      for _, id in ipairs(self.sprocket_ordering[i]) do
+        local sprocket = self.sprockets[id]
+        if sprocket.enabled then
+          sprocket.phase = sprocket.phase + 1
+          local swing_val = 2 * sprocket.swing / 100
+          if not sprocket.downbeat then
+            swing_val = 1
+          end
+          if sprocket.phase > sprocket.division * ppc * swing_val then
+            sprocket.phase = sprocket.phase - (sprocket.division * ppc)
+            if sprocket.delay_new ~= nil then
+              sprocket.phase = sprocket.phase - (sprocket.division * ppc) * (1 - (sprocket.delay - sprocket.delay_new))
+              sprocket.delay = sprocket.delay_new
+              sprocket.delay_new = nil
+            end
+            sprocket.action(self.transport)
+            sprocket.downbeat = not sprocket.downbeat
+          end
+        elseif sprocket.flag then
+          self.sprockets[sprocket.id] = nil
+          flagged = true
+        end
+      end
+    end
+    if flagged then
+      self:order_sprockets()
+    end
+    self.transport = self.transport + 1
+  end
+end
+
+--- factory method to add a new sprocket to this lattice
+-- @tparam[opt] table args optional named attributes are:
+-- - "action" (function) called on each step of this division (lattice.transport is passed as the argument), defaults to a no-op
+-- - "division" (number) the division of the sprocket, defaults to 1/4
+-- - "enabled" (boolean) is this sprocket enabled, defaults to true
+-- - "swing" (number) is the percentage of swing (0 - 100%), defaults to 50
+-- - "delay" (number) specifies amount of delay, as fraction of division (0.0 - 1.0), defaults to 0
+-- - "order" (number) specifies the place in line this lattice occupies from 1 to 5, lower first, defaults to 3
+-- @treturn table a new sprocket
+function Lattice:new_sprocket(args)
+  self.sprocket_id_counter = self.sprocket_id_counter + 1
+  args = args == nil and {} or args
+  args.id = self.sprocket_id_counter
+  args.order = args.order == nil and 3 or util.clamp(args.order, 1, 5)
+  args.action = args.action == nil and function(t) return end or args.action
+  args.division = args.division == nil and 1/4 or args.division
+  args.enabled = args.enabled == nil and true or args.enabled
+  args.phase = args.division * self.ppqn * 4 -- "4" because in music a "quarter note" == "1/4"
+  args.swing = args.swing == nil and 50 or util.clamp(args.swing,0,100)
+  args.delay = args.delay == nil and 0 or util.clamp(args.delay,0,1)
+  local sprocket = Sprocket:new(args)
+  self.sprockets[self.sprocket_id_counter] = sprocket
+  self:order_sprockets()
+  return sprocket
+end
+
+--- new_pattern is deprecated
+function Lattice:new_pattern(args)
+  print("'new_pattern' is deprecated; use 'new_sprocket' instead.")
+  return self:new_sprocket(args)
+end
+
+--- "private" method to keep numerical order of the sprocket ids
+-- for use when pulsing
+function Lattice:order_sprockets()
+  self.sprocket_ordering = {{}, {}, {}, {}, {}}
+  for id, sprocket in pairs(self.sprockets) do
+    table.insert(self.sprocket_ordering[sprocket.order],id)
+  end
+  for i = 1, 5 do
+    table.sort(self.sprocket_ordering[i])
+  end
+end
+
+--- "private" method to instantiate a new sprocket, only called by Lattice:new_sprocket()
+-- @treturn table a new sprocket
+function Sprocket:new(args)
+  local p = setmetatable({}, { __index = Sprocket })
+  p.id = args.id
+  p.order = args.order
+  p.division = args.division
+  p.action = args.action
+  p.enabled = args.enabled
+  p.flag = false
+  p.swing = args.swing
+  p.downbeat = false
+  p.delay = args.delay
+  p.phase = args.phase * (1-args.delay)
+  return p
+end
+
+--- start the sprocket
+function Sprocket:start()
+  self.enabled = true
+end
+
+--- stop the sprocket
+function Sprocket:stop()
+  self.enabled = false
+end
+
+--- toggle the sprocket
+function Sprocket:toggle()
+  self.enabled = not self.enabled
+end
+
+--- flag the sprocket to be destroyed
+function Sprocket:destroy()
+  self.enabled = false
+  self.flag = true
+end
+
+--- set the division of the sprocket
+-- @tparam number n the division of the sprocket
+function Sprocket:set_division(n)
+   self.division = n
+end
+
+--- set the action for this sprocket
+-- @tparam function the action
+function Sprocket:set_action(fn)
+  self.action = fn
+end
+
+--- set the swing of the sprocket
+-- @tparam number the swing value 0-100%
+function Sprocket:set_swing(swing)
+  self.swing = util.clamp(swing,0,100)
+end
+
+--- set the delay for this sprocket
+-- @tparam fraction of the time between beats to delay (0-1)
+function Sprocket:set_delay(delay)
+  self.delay_new = util.clamp(delay,0,1)
+end
+
+return Lattice

--- a/lua/lib/lfo.lua
+++ b/lua/lib/lfo.lua
@@ -1,0 +1,507 @@
+-- LFOs for general-purpose scripting
+-- @module lib.lfo
+-- inspired by contributions from @markwheeler (changes), @justmat (hnds), and @sixolet (toolkit)
+-- added by @dndrks + @sixolet, with improvements by @Dewb
+
+local lattice = require 'lattice'
+
+local LFO = {}
+LFO.__index = LFO
+
+local lfo_rates = {1/16,1/8,1/4,5/16,1/3,3/8,1/2,3/4,1,1.5,2,3,4,6,8,16,32,64,128,256,512,1024}
+local lfo_rates_as_strings = {"1/16","1/8","1/4","5/16","1/3","3/8","1/2","3/4","1","1.5","2","3","4","6","8","16","32","64","128","256","512","1024"}
+
+local params_per_entry = 14
+
+function LFO.init()
+  if seamstress.lfo == nil then
+    seamstress.lfo = {lattice = lattice:new()}
+  end
+end
+
+--- construct an LFO
+-- @param string shape The shape for this LFO (options: 'sine','saw','square','random'; default: 'sine')
+-- @param number min The minimum bound for this LFO (default: 0)
+-- @param number max The maximum bound for this LFO (default: 1)
+-- @param number depth The depth of modulation between min/max (range: 0.0 to 1.0; default: 0.0)
+-- @param string mode How to advance the LFO (options: 'clocked', 'free'; default: 'clocked')
+-- @param number period The timing of this LFO's advancement. If mode is 'clocked', argument is in beats. If mode is 'free', argument is in seconds.
+-- @param function action A callback function to perform as the LFO advances. This library passes both the scaled and the raw value to the callback function.
+function LFO.new(shape, min, max, depth, mode, period, action)
+  local i = {}
+  setmetatable(i, LFO)
+  i.init()
+  i.scaled = 0
+  i.raw = 0
+  i.phase_counter = 0
+  i.shape = shape == nil and 'sine' or shape
+  i.min = min == nil and 0 or min
+  i.max = max == nil and 1 or max
+  i.depth = depth == nil and 1 or depth
+  i.enabled = 0
+  i.mode = mode == nil and 'clocked' or mode
+  i.period = period == nil and 4 or period
+  i.reset_target = 'floor'
+  i.baseline = 'min'
+  i.offset = 0
+  i.ppqn = 96
+  i.controlspec = {
+    warp = 'linear',
+    step = 0.01,
+    units = '',
+    quantum = 0.01,
+    wrap = false,
+    formatter = nil
+  }
+  i.action = action == nil and (function(scaled, raw) end) or action
+  i.percentage = math.abs(i.min-i.max) * i.depth
+  i.scaled_min = i.min
+  i.scaled_max = i.max
+  i.mid = 0
+  i.rand_value = 0
+  return i
+end
+
+--- construct an LFO via table arguments
+-- eg. my_lfo:add{shape = 'sine', min = 200, max = 12000}
+-- @tparam string shape The shape for this LFO (options: 'sine','saw','square','random'; default: 'sine')
+-- @tparam number min The minimum bound for this LFO (default: 0)
+-- @tparam number max The maximum bound for this LFO (default: 1)
+-- @tparam number depth The depth of modulation between min/max (range: 0.0 to 1.0; default: 0.0)
+-- @tparam string mode How to advance the LFO (options: 'clocked', 'free'; default: 'clocked')
+-- @tparam number period The timing of this LFO's advancement. If mode is 'clocked', argument is in beats. If mode is 'free', argument is in seconds.
+-- @tparam function action A callback function to perform as the LFO advances. This library passes both the scaled and the raw value to the callback function.
+function LFO:add(args)
+  local shape = args.shape == nil and 'sine' or args.shape
+  local min = args.min == nil and 0 or args.min
+  local max = args.max == nil and 1 or args.max
+  local depth = args.depth == nil and 1 or args.depth
+  local mode = args.mode == nil and 'clocked' or args.mode
+  local period = args.period == nil and 4 or args.period
+  local action = args.action == nil and (function(scaled, raw) end) or args.action
+  return self.new(shape, min, max, depth, mode, period, action)
+end
+
+-- PARAMETERS UI /
+local function lfo_params_visibility(state, i)
+  params[state](params, "lfo_baseline_"..i)
+  params[state](params, "lfo_offset_"..i)
+  params[state](params, "lfo_depth_"..i)
+  params[state](params, "lfo_scaled_"..i)
+  params[state](params, "lfo_raw_"..i)
+  params[state](params, "lfo_mode_"..i)
+  if state == "show" then
+    if params:get("lfo_mode_"..i) == 1 then
+      params:hide("lfo_free_"..i)
+      params:show("lfo_clocked_"..i)
+    elseif params:get("lfo_mode_"..i) == 2 then
+      params:hide("lfo_clocked_"..i)
+      params:show("lfo_free_"..i)
+    end
+  else
+    params:hide("lfo_clocked_"..i)
+    params:hide("lfo_free_"..i)
+  end
+  params[state](params, "lfo_shape_"..i)
+  params[state](params, "lfo_min_"..i)
+  params[state](params, "lfo_max_"..i)
+  params[state](params, "lfo_reset_"..i)
+  params[state](params, "lfo_reset_target_"..i)
+  _menu.rebuild_params()
+end
+
+local function build_lfo_spec(lfo,i,bound)
+  params:add{
+    type = 'control',
+    id = 'lfo_'..bound..'_'..i,
+    name = 'lfo '..bound,
+    controlspec = controlspec.new(
+      lfo.min,
+      lfo.max,
+      lfo.controlspec.warp,
+      lfo.controlspec.step,
+      bound == 'min' and lfo.min or lfo.max,
+      lfo.controlspec.units,
+      lfo.controlspec.quantum,
+      lfo.controlspec.wrap
+    ),
+    formatter = lfo.controlspec.formatter
+  }
+  params:set_action('lfo_'..bound..'_'..i, function(x)
+    lfo:set(bound,x)
+  end)
+end
+
+local function lfo_bang(i)
+  local function lb(prm)
+    params:lookup_param("lfo_"..prm.."_"..i):bang()
+  end
+  lb('depth')
+  lb('min')
+  lb('max')
+  lb('baseline')
+  lb('offset')
+  lb('mode')
+  lb('clocked')
+  lb('free')
+  lb('shape')
+  lb('reset')
+  lb('reset_target')
+end
+
+-- / PARAMETERS UI
+
+-- SCRIPTING /
+
+local function scale_lfo(target)
+  if target.baseline == 'min' then
+    target.scaled_min = target.min
+    target.scaled_max = target.min + target.percentage
+    target.mid = util.linlin(target.min,target.max,target.scaled_min,target.scaled_max,(target.min+target.max)/2)
+  elseif target.baseline == 'center' then
+    target.mid = (target.min+target.max)/2
+    local centroid_mid = math.abs(target.min-target.max) * (target.depth/2)
+    target.scaled_min = util.clamp(target.mid - centroid_mid,target.min,target.max)
+    target.scaled_max = util.clamp(target.mid + centroid_mid,target.min,target.max)
+  elseif target.baseline == 'max' then
+    target.mid = (target.min+target.max)/2
+    target.scaled_min = target.max * (1-(target.depth))
+    target.scaled_max = target.max
+    target.mid = math.abs(util.linlin(target.min,target.max,target.scaled_min,target.scaled_max,target.mid))
+  end
+end
+
+local function change_bound(target, which, value)
+  target[which] = value
+  target.percentage = math.abs(target.min-target.max) * target.depth
+  scale_lfo(target)
+end
+
+local function change_baseline(target, value)
+  target.baseline = value
+  scale_lfo(target)
+end
+
+local function change_depth(target, value)
+  target.depth = value
+  target.percentage = math.abs(target.min-target.max) * value
+  scale_lfo(target)
+end
+
+local function change_ppqn(target, ppqn)
+  target.ppqn = ppqn
+  if target.sprocket then
+    target.sprocket:set_division(1/(4*ppqn))
+  end
+end
+
+local function change_period(target, new_period)
+  local new_phase_counter = target.phase_counter + (1/target.ppqn)
+  local new_phase
+  local adjusted_phase_counter
+  if target.mode == "clocked" then
+    new_phase = new_phase_counter / target.period
+    adjusted_phase_counter = (new_phase * new_period) - 1/target.ppqn
+  else
+    new_phase = new_phase_counter * clock.get_beat_sec() / target.period
+    adjusted_phase_counter = (new_phase * new_period / clock.get_beat_sec()) - 1/target.ppqn
+  end
+
+  target.period = new_period
+  target.phase_counter = adjusted_phase_counter
+end
+
+local function process_lfo(id)
+  local _lfo = id
+  local phase
+
+  _lfo.phase_counter = _lfo.phase_counter + (1/_lfo.ppqn)
+  if _lfo.mode == "clocked" then
+    phase = _lfo.phase_counter / _lfo.period
+  else
+    phase = _lfo.phase_counter * clock.get_beat_sec() / _lfo.period
+  end
+  phase = phase % 1
+
+  if _lfo.enabled == 1 then
+
+    local current_val;
+    if _lfo.shape == 'sine' then
+      current_val = (math.sin(2*math.pi*phase) + 1)/2
+    elseif _lfo.shape == 'saw' then
+      current_val = phase < 0.5 and phase/0.5 or 1-(phase-0.5)/(0.5)
+    elseif _lfo.shape == 'square' then
+      current_val = phase < 0.5 and 1 or 0
+    elseif _lfo.shape == 'random' then
+      current_val = (math.sin(2*math.pi*phase) + 1)/2
+    end
+
+    local min = _lfo.min
+    local max = _lfo.max
+
+    if _lfo.shape ~= 'random' then
+      _lfo.raw = current_val
+    end
+    current_val = current_val + _lfo.offset
+    local value = util.linlin(0,1,min,min + _lfo.percentage,current_val)
+
+    if _lfo.depth > 0 then
+
+      if _lfo.baseline == 'center' then
+        value = util.linlin(0,1,_lfo.scaled_min,_lfo.scaled_max,current_val)
+      elseif _lfo.baseline == 'max' then
+        value = util.linlin(0,1,_lfo.scaled_max,_lfo.scaled_min,current_val)
+      end
+
+      if _lfo.shape == "sine" or  _lfo.shape == "saw" then
+        value = util.clamp(value,min,max)
+        _lfo.scaled = value
+      elseif _lfo.shape == "square" then
+        local square_value = value >= _lfo.mid and max or min
+        square_value = util.linlin(min,max,_lfo.scaled_min,_lfo.scaled_max,square_value)
+        square_value = util.clamp(square_value,_lfo.scaled_min,_lfo.scaled_max)
+        _lfo.scaled = square_value
+        _lfo.raw = util.linlin(_lfo.scaled_min,_lfo.scaled_max,0,1,square_value)
+      elseif _lfo.shape == "random" then
+        local prev_value = _lfo.rand_value
+        _lfo.rand_value = value >= _lfo.mid and max or min
+        local rand_value;
+        if prev_value ~= _lfo.rand_value then
+          rand_value = util.linlin(min,max,_lfo.scaled_min,_lfo.scaled_max,math.random(math.floor(min*100),math.floor(max*100))/100)
+          rand_value = util.clamp(rand_value,min,max)
+          _lfo.scaled = rand_value
+          _lfo.raw = util.linlin(_lfo.scaled_min,_lfo.scaled_max,0,1,rand_value)
+        end
+      end
+
+      _lfo.action(_lfo.scaled, _lfo.raw)
+
+      if _lfo.parameter_id ~= nil then
+        params:set("lfo_scaled_".._lfo.parameter_id,util.round(_lfo.scaled,0.01))
+        params:set("lfo_raw_".._lfo.parameter_id,util.round(_lfo.raw,0.01))
+      end
+
+    end
+  end
+end
+
+--- start LFO
+function LFO:start()
+  if self.sprocket == nil then
+    self:reset_phase()
+    self.sprocket = seamstress.lfo.lattice:new_sprocket{
+      action=function() process_lfo(self) end,
+      division=1/(4*self.ppqn),
+      enabled=true,
+    }
+    if not seamstress.lfo.lattice.enabled then
+      seamstress.lfo.lattice:start()
+    end
+    self.enabled = 1
+  end
+end
+
+--- stop LFO
+function LFO:stop()
+  if self.sprocket ~= nil then
+    self.sprocket:destroy()
+    self.sprocket = nil
+    self.enabled = 0
+    if next(seamstress.lfo.lattice.sprockets) == nil then
+      seamstress.lfo.lattice:stop()
+    end
+  end
+end
+
+--- set LFO variable state
+-- @tparam string var The variable to target (options: 'shape', 'min', 'max', 'depth', 'offset', 'mode', 'period', 'reset_target', 'baseline', 'action', 'ppqn')
+-- @tparam various arg The argument to pass to the target (often numbers + strings, but 'action' expects a function)
+function LFO:set(var, arg)
+  if var == nil then
+    error('scripted LFO variable required')
+  elseif var == 'min' or var == 'max' then
+    change_bound(self, var, arg)
+  elseif var == 'depth' then
+    change_depth(self, arg)
+  elseif var == 'baseline' then
+    change_baseline(self, arg)
+  elseif var == 'ppqn' then
+    change_ppqn(self, arg)
+  elseif var == 'period' then
+    change_period(self, arg)
+  elseif arg == nil then
+    error('scripted LFO argument required')
+  elseif not self[var] then
+    error("scripted LFO variable '"..var.."' not valid")
+  else
+    self[var] = arg
+  end
+end
+
+--- get LFO variable state
+-- @tparam string var The variable to query (options: 'shape', 'min', 'max', 'depth', 'offset', 'mode', 'period', 'reset_target', 'baseline', 'action', 'enabled', 'controlspec')
+function LFO:get(var)
+  if var == nil then
+    error('scripted LFO variable required')
+  elseif not self[var] then
+    error("scripted LFO variable '"..var.."' not valid")
+  else
+    return self[var]
+  end
+end
+
+--- reset the LFO's phase
+function LFO:reset_phase()
+  if self.mode == "free" then
+    local baseline = clock.get_beat_sec()/self.period
+    if self.reset_target == "floor" then
+      self.phase_counter = 0.75/baseline
+    elseif self.reset_target == "ceiling" then
+      self.phase_counter = 0.25/baseline
+    elseif self.reset_target == "mid: falling" then
+      self.phase_counter = 0.5/baseline
+    elseif self.reset_target == "mid: rising" then
+      self.phase_counter = baseline
+    end
+  else
+    if self.reset_target == "floor" then
+      self.phase_counter = 0.75 * (self.period)
+    elseif self.reset_target == "ceiling" then
+      self.phase_counter = 0.25 * (self.period)
+    elseif self.reset_target == "mid: falling" then
+      self.phase_counter = 0.5 * (self.period)
+    elseif self.reset_target == "mid: rising" then
+      self.phase_counter = self.period
+    end
+  end
+end
+
+-- / SCRIPT LFOS
+
+--- Build parameter menu UI for an already-constructed LFO.
+-- @tparam string id The parameter ID to use for this LFO.
+-- @tparam[opt] string separator A separator name for the LFO parameters.
+-- @tparam[opt] string group A group name for the LFO parameters.
+function LFO:add_params(id,sep,group)
+  if id ~= nil then
+    if params.lookup["lfo_"..id] == nil then
+
+      if group then
+        if sep ~= nil then
+          params:add_group("lfo_group_"..id,group,params_per_entry+1)
+        else
+          params:add_group("lfo_group_"..id,group,params_per_entry)
+        end
+      end
+
+      if sep then
+        params:add_separator("lfo_sep_"..sep,sep)
+      end
+
+      params:add_option("lfo_"..id,"lfo state",{"off","on"},1)
+      params:set_action("lfo_"..id,function(x)
+        if x == 1 then
+          lfo_params_visibility("hide", id)
+          params:set("lfo_scaled_"..id,"")
+          params:set("lfo_raw_"..id,"")
+          self:stop()
+        elseif x == 2 then
+          lfo_params_visibility("show", id)
+          self:start()
+        end
+        self:set('enabled',x-1)
+        lfo_bang(id)
+      end)
+
+      params:add_option("lfo_shape_"..id, "lfo shape", {"sine","saw","square","random"},1)
+      params:set_action("lfo_shape_"..id, function(x) self:set('shape', params:lookup_param("lfo_shape_"..id).options[x]) end)
+
+      params:add_number("lfo_depth_"..id,"lfo depth",0,100,0,function(param) return (param:get().."%") end)
+      params:set_action("lfo_depth_"..id, function(x)
+        if x == 0 then
+          params:set("lfo_scaled_"..id,"")
+          params:set("lfo_raw_"..id,"")
+        end
+        self:set('depth',x/100)
+      end)
+
+      params:add_number('lfo_offset_'..id, 'lfo offset', -100, 100, 0, function(param) return (param:get().."%") end)
+      params:set_action("lfo_offset_"..id, function(x)
+        self:set('offset',x/100)
+      end)
+
+      params:add_text("lfo_scaled_"..id,"  scaled value","")
+      params:add_text("lfo_raw_"..id,"  raw value","")
+
+      build_lfo_spec(self,id,"min")
+      build_lfo_spec(self,id,"max")
+
+      local baseline_options;
+      baseline_options = {"from min", "from center", "from max"}
+      params:add_option("lfo_baseline_"..id, "lfo baseline", baseline_options, 1)
+      params:set_action("lfo_baseline_"..id, function(x)
+        self:set('baseline',string.gsub(params:lookup_param("lfo_baseline_"..id).options[x],"from ",""))
+        _menu.rebuild_params()
+      end)
+
+      params:add_option("lfo_mode_"..id, "lfo mode", {"clocked","free"},1)
+      params:set_action("lfo_mode_"..id,
+        function(x)
+          self:set('mode',params:lookup_param("lfo_mode_"..id).options[x])
+          self:set(
+            'period',
+            x == 1 and (lfo_rates[params:get('lfo_clocked_'..id)] * 4) or params:get('lfo_free_'..id)
+          )
+          if x == 1 and params:string("lfo_"..id) == "on" then
+            params:hide("lfo_free_"..id)
+            params:show("lfo_clocked_"..id)
+          elseif x == 2 and params:string("lfo_"..id) == "on" then
+            params:hide("lfo_clocked_"..id)
+            params:show("lfo_free_"..id)
+          end
+          _menu.rebuild_params()
+        end
+        )
+
+      params:add_option("lfo_clocked_"..id, "lfo rate", lfo_rates_as_strings, 9)
+      params:set_action("lfo_clocked_"..id,
+        function(x)
+          if params:string("lfo_mode_"..id) == "clocked" then
+            self:set('period',lfo_rates[x] * 4)
+          end
+        end
+      )
+
+      params:add{
+        type='control',
+        id="lfo_free_"..id,
+        name="lfo rate",
+        controlspec=controlspec.new(0.1,300,'exp',0.1,1,'sec')
+      }
+      params:set_action("lfo_free_"..id, function(x)
+        if params:string("lfo_mode_"..id) == "free" then
+          self:set('period', x)
+        end
+      end)
+
+      params:add_trigger("lfo_reset_"..id, "reset lfo")
+      params:set_action("lfo_reset_"..id, function(x) self:reset_phase() end)
+
+      params:add_option("lfo_reset_target_"..id, "reset lfo to", {"floor","ceiling","mid: rising","mid: falling"}, 1)
+      params:set_action("lfo_reset_target_"..id, function(x)
+        self:set('reset_target', params:lookup_param("lfo_reset_target_"..id).options[x])
+      end)
+
+      params:hide("lfo_free_"..id)
+
+      params:lookup_param("lfo_"..id):bang()
+      self.parameter_id = id
+    else
+      print('! params for LFO '..id..' already added !')
+    end
+  else
+    print('! parameter id is required to add LFO parameters')
+  end
+end
+
+return LFO

--- a/lua/lib/musicutil.lua
+++ b/lua/lib/musicutil.lua
@@ -1,0 +1,636 @@
+--- Music utility module.
+-- Utility methods for working with notes, scales and chords.
+--
+-- @module lib.MusicUtil
+-- @release v1.1.2
+-- @author Mark Eats
+
+local MusicUtil = {}
+
+MusicUtil.NOTE_NAMES = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}
+MusicUtil.SCALES = {
+  {name = "Major", alt_names = {"Ionian"}, intervals = {0, 2, 4, 5, 7, 9, 11, 12}, chords = {{1, 2, 3, 4, 5, 6, 7, 14}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19}, {1, 2, 3, 4, 5}, {1, 2, 4, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 19, 21, 22}, {24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}}},
+  {name = "Natural Minor", alt_names = {"Minor", "Aeolian"}, intervals = {0, 2, 3, 5, 7, 8, 10, 12}, chords = {{14, 15, 17, 19, 21, 22}, {24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19}, {1, 2, 3, 4, 5}, {1, 2, 4, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 19, 21, 22}}},
+  {name = "Harmonic Minor", intervals = {0, 2, 3, 5, 7, 8, 11, 12}, chords = {{14, 16, 17}, {24, 25, 26}, {12}, {17, 18, 19, 20, 21, 24, 25, 26}, {1, 8, 12, 13, 14, 15}, {1, 2, 3, 16, 17, 18, 24, 25}, {12, 24, 25}, {14, 16, 17}}},
+  {name = "Melodic Minor", intervals = {0, 2, 3, 5, 7, 9, 11, 12}, chords = {{14, 16, 17, 18, 20}, {14, 15, 17, 18, 19}, {12}, {1, 2, 4, 8, 9}, {1, 8, 9, 10, 12, 13, 14, 15}, {24, 26}, {12, 13, 24, 26}, {14, 16, 17, 18, 20}}},
+  {name = "Dorian", intervals = {0, 2, 3, 5, 7, 9, 10, 12}, chords = {{14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19}, {1, 2, 3, 4, 5}, {1, 2, 4, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 19, 21, 22}, {24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}, {14, 15, 17, 18, 19, 20, 21, 22, 23}}},
+  {name = "Phrygian", intervals = {0, 1, 3, 5, 7, 8, 10, 12}, chords = {{14, 15, 17, 19}, {1, 2, 3, 4, 5}, {1, 2, 4, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 19, 21, 22}, {24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19}}},
+  {name = "Lydian", intervals = {0, 2, 4, 6, 7, 9, 11, 12}, chords = {{1, 2, 3, 4, 5}, {1, 2, 4, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 19, 21, 22}, {24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19}, {1, 2, 3, 4, 5}}},
+  {name = "Mixolydian", intervals = {0, 2, 4, 5, 7, 9, 10, 12}, chords = {{1, 2, 4, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 19, 21, 22}, {24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19}, {1, 2, 3, 4, 5}, {1, 2, 4, 8, 9, 10, 11, 14, 15}}},
+  {name = "Locrian", intervals = {0, 1, 3, 5, 6, 8, 10, 12}, chords = {{24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19}, {1, 2, 3, 4, 5}, {1, 2, 4, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 19, 21, 22}, {24, 26}}},
+  {name = "Whole Tone", intervals = {0, 2, 4, 6, 8, 10, 12}, chords = {{12, 13}, {12, 13}, {12, 13}, {12, 13}, {12, 13}, {12, 13}, {12, 13}}},
+  {name = "Major Pentatonic", alt_names = {"Gagaku Ryo Sen Pou"}, intervals = {0, 2, 4, 7, 9, 12}, chords = {{1, 2, 4}, {14, 15}, {}, {14}, {14, 15, 17, 19}, {1, 2, 4}}},
+  {name = "Minor Pentatonic", alt_names = {"Zokugaku Yo Sen Pou"}, intervals = {0, 3, 5, 7, 10, 12}, chords = {{14, 15, 17, 19}, {1, 2, 4}, {14, 15}, {}, {14}, {14, 15, 17, 19}}},
+  {name = "Major Bebop", intervals = {0, 2, 4, 5, 7, 8, 9, 11, 12}, chords = {{1, 2, 3, 4, 5, 6, 7, 12, 14}, {14, 15, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 8, 12, 13, 14, 15, 17, 19}, {1, 2, 3, 4, 5, 16, 17, 18, 20, 24, 25}, {1, 2, 4, 8, 9, 10, 11, 14, 15}, {12, 24, 25}, {14, 15, 16, 17, 19, 21, 22}, {24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 12, 14}}},
+  {name = "Altered Scale", intervals = {0, 1, 3, 4, 6, 8, 10, 12}, chords = {{12, 13, 24, 26}, {14, 16, 17, 18, 20}, {14, 15, 17, 18, 19}, {12}, {1, 2, 4, 8, 9}, {1, 8, 9, 10, 12, 13, 14, 15}, {24, 26}, {12, 13, 24, 26}}},
+  {name = "Dorian Bebop", intervals = {0, 2, 3, 4, 5, 7, 9, 10, 12}, chords = {{1, 2, 4, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19, 21, 22}, {1, 2, 3, 4, 5}, {24, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19, 24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}, {1, 2, 4, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20, 21, 22, 23}}},
+  {name = "Mixolydian Bebop", intervals = {0, 2, 4, 5, 7, 9, 10, 11, 12}, chords = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 15}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19, 24, 26}, {1, 2, 3, 4, 5, 6, 7, 14}, {1, 2, 4, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20, 21, 22, 23}, {14, 15, 17, 19, 21, 22}, {1, 2, 3, 4, 5}, {24, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 15}}},
+  {name = "Blues Scale", alt_names = {"Blues"}, intervals = {0, 3, 5, 6, 7, 10, 12}, chords = {{14, 15, 17, 19, 24, 26}, {1, 2, 4, 17, 18, 20}, {14, 15}, {}, {}, {14}, {14, 15, 17, 19, 24, 26}}},
+  {name = "Diminished Whole Half", intervals = {0, 2, 3, 5, 6, 8, 9, 11, 12}, chords = {{24, 25}, {1, 2, 8, 17, 18, 19, 24, 25, 26}, {24, 25}, {1, 2, 8, 17, 18, 19, 24, 25, 26}, {24, 25}, {1, 2, 8, 17, 18, 19, 24, 25, 26}, {24, 25}, {1, 2, 8, 17, 18, 19, 24, 25, 26}, {24, 25}}},
+  {name = "Diminished Half Whole", intervals = {0, 1, 3, 4, 6, 7, 9, 10, 12}, chords = {{1, 2, 8, 17, 18, 19, 24, 25, 26}, {24, 25}, {1, 2, 8, 17, 18, 19, 24, 25, 26}, {24, 25}, {1, 2, 8, 17, 18, 19, 24, 25, 26}, {24, 25}, {1, 2, 8, 17, 18, 19, 24, 25, 26}, {24, 25}, {1, 2, 8, 17, 18, 19, 24, 25, 26}}},
+  {name = "Neapolitan Major", intervals = {0, 1, 3, 5, 7, 9, 11, 12}, chords = {{14, 16, 17, 18}, {12, 13}, {12, 13}, {1, 8, 9, 12, 13}, {12, 13}, {12, 13, 24, 26}, {12, 13}, {14, 16, 17, 18}}},
+  {name = "Hungarian Major", intervals = {0, 3, 4, 6, 7, 9, 10, 12}, chords = {{1, 2, 8, 17, 18, 19, 24, 25, 26}, {1, 2, 17, 18, 24, 25}, {24}, {24, 25, 26}, {}, {17, 18, 19, 24, 25, 26}, {}, {1, 2, 8, 17, 18, 19, 24, 25, 26}}},
+  {name = "Harmonic Major", intervals = {0, 2, 4, 5, 7, 8, 11, 12}, chords = {{1, 3, 5, 6, 12, 14}, {24, 25, 26}, {1, 8, 12, 13, 17, 19}, {16, 17, 18, 20, 24, 25}, {1, 2, 8, 14, 15}, {12, 24, 25}, {24, 25}, {1, 3, 5, 6, 12, 14}}},
+  {name = "Hungarian Minor", intervals = {0, 2, 3, 6, 7, 8, 11, 12}, chords = {{16, 17, 24}, {}, {12}, {}, {1, 3, 12, 14}, {1, 3, 8, 16, 17, 19, 24, 26}, {1, 2, 12, 17, 18}, {16, 17, 24}}},
+  {name = "Lydian Minor", intervals = {0, 2, 4, 6, 7, 8, 10, 12}, chords = {{1, 8, 9, 12, 13}, {12, 13}, {12, 13, 24, 26}, {12, 13}, {14, 16, 17, 18}, {12, 13}, {12, 13}, {1, 8, 9, 12, 13}}},
+  {name = "Neapolitan Minor", alt_names = {"Byzantine"}, intervals = {0, 1, 3, 5, 7, 8, 11, 12}, chords = {{14, 16, 17}, {1, 3, 5, 8, 9}, {12, 13}, {17, 19, 21, 24, 26}, {12, 13}, {1, 2, 3, 14, 16, 17, 18}, {12}, {14, 16, 17}}},
+  {name = "Major Locrian", intervals = {0, 2, 4, 5, 6, 8, 10, 12}, chords = {{12, 13}, {12, 13, 24, 26}, {12, 13}, {14, 16, 17, 18}, {12, 13}, {12, 13}, {1, 8, 9, 12, 13}, {12, 13}}},
+  {name = "Leading Whole Tone", intervals = {0, 2, 4, 6, 8, 10, 11, 12}, chords = {{12, 13}, {12, 13}, {1, 8, 9, 12, 13}, {12, 13}, {12, 13, 24, 26}, {12, 13}, {14, 16, 17, 18}, {12, 13}}},
+  {name = "Six Tone Symmetrical", intervals = {0, 1, 4, 5, 8, 9, 11, 12}, chords = {{12}, {1, 3, 8, 12, 13, 16, 17, 19}, {1, 2, 12, 14}, {1, 3, 12, 16, 17, 24}, {12}, {1, 3, 5, 12, 16, 17}, {}, {12}}},
+  {name = "Balinese", intervals = {0, 1, 3, 7, 8, 12}, chords = {{17}, {}, {}, {}, {1, 3, 14}, {17}}},
+  {name = "Persian", intervals = {0, 1, 4, 5, 6, 8, 11, 12}, chords = {{12}, {1, 3, 8, 14, 15, 16, 17, 19}, {1, 2, 4, 12}, {16, 17, 24}, {14, 15}, {12, 13}, {14}, {12}}},
+  {name = "East Indian Purvi", intervals = {0, 1, 4, 6, 7, 8, 11, 12}, chords = {{1, 3, 12}, {14, 15, 16, 17, 19, 24, 26}, {1, 2, 4, 12, 17, 18, 20}, {14, 15}, {}, {12, 13}, {14}, {1, 3, 12}}},
+  {name = "Oriental", intervals = {0, 1, 4, 5, 6, 9, 10, 12}, chords = {{}, {12}, {}, {1, 3, 12, 14}, {1, 3, 8, 16, 17, 19, 24, 26}, {1, 2, 12, 17, 18}, {16, 17, 24}, {}}},
+  {name = "Double Harmonic", intervals = {0, 1, 4, 5, 7, 8, 11, 12}, chords = {{1, 3, 12, 14}, {1, 3, 8, 16, 17, 19, 24, 26}, {1, 2, 12, 17, 18}, {16, 17, 24}, {}, {12}, {}, {1, 3, 12, 14}}},
+  {name = "Enigmatic", intervals = {0, 1, 4, 6, 8, 10, 11, 12}, chords = {{12, 13}, {14, 15, 16, 17, 18, 19}, {1, 2, 4, 12}, {1, 8, 9, 10, 14, 15}, {12, 13}, {24, 26}, {14}, {12, 13}}},
+  {name = "Overtone", intervals = {0, 2, 4, 6, 7, 9, 10, 12}, chords = {{1, 2, 4, 8, 9}, {1, 8, 9, 10, 12, 13, 14, 15}, {24, 26}, {12, 13, 24, 26}, {14, 16, 17, 18, 20}, {14, 15, 17, 18, 19}, {12}, {1, 2, 4, 8, 9}}},
+  {name = "Eight Tone Spanish", intervals = {0, 1, 3, 4, 5, 6, 8, 10, 12}, chords = {{12, 13, 24, 26}, {1, 2, 3, 4, 5, 6, 7, 14, 16, 17, 18, 20}, {14, 15, 17, 18, 19, 20, 21, 22, 23}, {12}, {14, 15, 16, 17, 19}, {1, 2, 3, 4, 5, 8, 9}, {1, 2, 4, 8, 9, 10, 11, 12, 13, 14, 15}, {14, 15, 17, 19, 21, 22, 24, 26}, {12, 13, 24, 26}}},
+  {name = "Prometheus", intervals = {0, 2, 4, 6, 9, 10, 12}, chords = {{}, {1, 8, 9, 12, 13}, {}, {12, 13, 24, 26}, {14, 17, 18}, {12}, {}}},
+  {name = "Gagaku Rittsu Sen Pou", intervals = {0, 2, 5, 7, 9, 10, 12}, chords = {{14, 15}, {14, 15, 17, 19}, {1, 2, 4, 14}, {14, 15, 17, 19, 21, 22}, {}, {1, 2, 3, 4, 5}, {14, 15}}},
+  {name = "In Sen Pou", intervals = {0, 1, 5, 2, 8, 12}, chords = {{}, {1, 3}, {17, 18}, {24, 26}, {}, {}}},
+  {name = "Okinawa", intervals = {0, 4, 5, 7, 11, 12}, chords = {{1, 3, 14}, {17}, {}, {}, {}, {1, 3, 14}}},
+  {name = "Chromatic", intervals = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, chords = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}}}
+}
+MusicUtil.CHORDS = {
+  {name = "Major", alt_names = {"Maj"}, intervals = {0, 4, 7}},
+  {name = "Major 6", alt_names = {"Maj6"}, intervals = {0, 4, 7, 9}},
+  {name = "Major 7", alt_names = {"Maj7"}, intervals = {0, 4, 7, 11}},
+  {name = "Major 69", alt_names = {"Maj69"}, intervals = {0, 4, 7, 9, 14}},
+  {name = "Major 9", alt_names = {"Maj9"}, intervals = {0, 4, 7, 11, 14}},
+  {name = "Major 11", alt_names = {"Maj11"}, intervals = {0, 4, 7, 11, 14, 17}},
+  {name = "Major 13", alt_names = {"Maj13"}, intervals = {0, 4, 7, 11, 14, 17, 21}},
+  {name = "Dominant 7", intervals = {0, 4, 7, 10}},
+  {name = "Ninth", intervals = {0, 4, 7, 10, 14}},
+  {name = "Eleventh", intervals = {0, 4, 7, 10, 14, 17}},
+  {name = "Thirteenth", intervals = {0, 4, 7, 10, 14, 17, 21}},
+  {name = "Augmented", intervals = {0, 4, 8}},
+  {name = "Augmented 7", intervals = {0, 4, 8, 10}},
+  {name = "Sus4", intervals = {0, 5, 7}},
+  {name = "Seventh sus4", intervals = {0, 5, 7, 10}},
+  {name = "Minor Major 7", alt_names = {"MinMaj7"}, intervals = {0, 3, 7, 11}},
+  {name = "Minor", alt_names = {"Min"}, intervals = {0, 3, 7}},
+  {name = "Minor 6", alt_names = {"Min6"}, intervals = {0, 3, 7, 9}},
+  {name = "Minor 7", alt_names = {"Min7"}, intervals = {0, 3, 7, 10}},
+  {name = "Minor 69", alt_names = {"Min69"}, intervals = {0, 3, 7, 9, 14}},
+  {name = "Minor 9", alt_names = {"Min9"}, intervals = {0, 3, 7, 10, 14}},
+  {name = "Minor 11", alt_names = {"Min11"}, intervals = {0, 3, 7, 10, 14, 17}},
+  {name = "Minor 13", alt_names = {"Min13"}, intervals = {0, 3, 7, 10, 14, 17, 21}},
+  {name = "Diminished", alt_names = {"Dim"}, intervals = {0, 3, 6}},
+  {name = "Diminished 7", alt_names = {"Dim7"}, intervals = {0, 3, 6, 9}},
+  {name = "Half Diminished 7", intervals = {0, 3, 6, 10}}
+}
+-- Data from https://github.com/fredericcormier/WesternMusicElements
+
+MusicUtil.SCALE_CHORD_DEGREES = {
+  {
+    name = "Major",
+    chords = {
+      "I",  "ii",  "iii",  "IV",  "V",  "vi",  "vii\u{B0}",
+      "I7", "ii7", "iii7", "IV7", "V7", "vi7", "vii\u{B0}7"
+    }
+  },
+  {
+    name = "Natural Minor",
+    chords = {
+      "i",  "ii\u{B0}",  "III",  "iv",  "v",  "VI",  "VII",
+      "i7", "ii\u{B0}7", "III7", "iv7", "v7", "VI7", "VII7"
+    }
+  },
+  {
+    name = "Harmonic Minor",
+    chords = {
+      "i",  "ii\u{B0}",  "III+",  "iv",  "V",  "VI",  "vii\u{B0}",
+      "i7", "ii\u{B0}7", "III+7", "iv7", "V7", "VI7", "vii\u{B0}7"
+    }
+  },
+  {
+    name = "Melodic Minor",
+    chords = {
+      "i",  "ii",  "III+",  "IV",  "V",  "vi\u{B0}",  "vii\u{B0}",
+      "i7", "ii7", "III+7", "IV7", "V7", "vi\u{B0}7", "vii\u{B0}7"
+    }
+  },
+  {
+    name = "Dorian",
+    chords = {
+      "i",  "ii",  "III",  "IV",  "v",  "vi\u{B0}",  "VII",
+      "i7", "ii7", "III7", "IV7", "v7", "vi\u{B0}7", "VII7"
+    }
+  },
+  {
+    name = "Phrygian",
+    chords = {
+      "i",  "II",  "III",  "iv",  "v\u{B0}",  "VI",  "vii",
+      "i7", "II7", "III7", "iv7", "v\u{B0}7", "VI7", "vii7"
+    }
+  },
+  {
+    name = "Lydian",
+    chords = {
+      "I",  "II",  "iii",  "iv\u{B0}",  "V",  "vi",  "vii",
+      "I7", "II7", "iii7", "iv\u{B0}7", "V7", "vi7", "vii7"
+    }
+  },
+  {
+    name = "Mixolydian",
+    chords = {
+      "I",  "ii",  "iii\u{B0}",  "IV",  "v",  "vi",  "VII",
+      "I7", "ii7", "iii\u{B0}7", "IV7", "v7", "vi7", "VII7"
+    }
+  },
+  {
+    name = "Locrian",
+    chords = {
+      "i\u{B0}",  "II",  "iii",  "iv",  "V",  "VI",  "vii",
+      "i\u{B0}7", "II7", "iii7", "iv7", "V7", "VI7", "vii7"
+    }
+  },
+}
+
+
+
+-- Used offline to generate the chord cross-references in the SCALES table above
+-- Needs to be updated when either SCALES or CHORDS changes
+--[[
+local function generate_chord_lookups()
+  
+  for s = 1, #MusicUtil.SCALES do
+    MusicUtil.SCALES[s].chords = {}
+    local num_scale_intervals = #MusicUtil.SCALES[s].intervals
+    for si = 1, num_scale_intervals do
+      MusicUtil.SCALES[s].chords[si] = {}
+      for c = 1, #MusicUtil.CHORDS do
+        local in_key = true
+        for ci = 1, #MusicUtil.CHORDS[c].intervals do
+          local chord_interval_in_key = false
+          for sii = 1, num_scale_intervals do
+            if (MusicUtil.CHORDS[c].intervals[ci] + MusicUtil.SCALES[s].intervals[si]) % 12 == MusicUtil.SCALES[s].intervals[sii] then
+              chord_interval_in_key = true
+              break
+            end
+          end
+          if not chord_interval_in_key then
+            in_key = false
+            break
+          end
+        end
+        if in_key then
+          table.insert(MusicUtil.SCALES[s].chords[si], c)
+        end
+      end
+    end
+
+    -- Print it all
+    local scale_string = ""
+    scale_string = "{name = \"" .. MusicUtil.SCALES[s].name .. "\""
+
+    if MusicUtil.SCALES[s].alt_names then
+      scale_string = scale_string .. ", alt_names = {"
+      for an = 1, #MusicUtil.SCALES[s].alt_names do
+        scale_string = scale_string .. "\"" .. MusicUtil.SCALES[s].alt_names[an] .. "\""
+        if an < #MusicUtil.SCALES[s].alt_names then
+          scale_string = scale_string .. ", "
+        end
+      end
+    scale_string = scale_string .. "}"
+    end
+    scale_string = scale_string .. ", intervals = {"
+    for int = 1, #MusicUtil.SCALES[s].intervals do
+      scale_string = scale_string .. MusicUtil.SCALES[s].intervals[int]
+      if int < #MusicUtil.SCALES[s].intervals then
+        scale_string = scale_string .. ", "
+      end
+    end
+    scale_string = scale_string .. "}, chords = {"
+    for c = 1, #MusicUtil.SCALES[s].chords do
+      scale_string = scale_string .. "{"
+      for ci = 1, #MusicUtil.SCALES[s].chords[c] do
+        scale_string = scale_string .. MusicUtil.SCALES[s].chords[c][ci]
+        if ci < #MusicUtil.SCALES[s].chords[c] then
+          scale_string = scale_string .. ", "
+        end
+      end
+      scale_string = scale_string .. "}"
+      if c < #MusicUtil.SCALES[s].chords then
+        scale_string = scale_string .. ", "
+      end
+    end
+    scale_string = scale_string .. "}}"
+    if s < #MusicUtil.SCALES then
+      scale_string = scale_string .. ","
+    end
+    print(scale_string)
+
+  end
+end
+generate_chord_lookups()
+--]]
+
+local function lookup_data(lookup_table, search)
+  
+  if type(search) == "string" then 
+    search = string.lower(search)
+    for i = 1, #lookup_table do
+      if string.lower(lookup_table[i].name) == search then
+        search = i
+        break
+      elseif lookup_table[i].alt_names then
+        local found = false
+        for j = 1, #lookup_table[i].alt_names do
+          if string.lower(lookup_table[i].alt_names[j]) == search then
+            search = i
+            found = true
+            break
+          end
+        end
+        if found then break end
+      end
+    end
+  end
+  
+  return lookup_table[search]
+end
+
+local function generate_scale_array(root_num, scale_data, length)
+  local out_array = {}
+  local scale_len = #scale_data.intervals
+  local note_num
+  local i = 0
+  while #out_array < length do
+    if i > 0 and i % scale_len == 0 then
+      root_num = root_num + scale_data.intervals[scale_len]
+    else
+      note_num = root_num + scale_data.intervals[i % scale_len + 1]
+      if note_num > 127 then break
+      else table.insert(out_array, note_num) end
+    end
+    i = i + 1
+  end
+  return out_array
+end
+
+
+--- Generate scale from a root note.
+-- @tparam integer root_num MIDI note number (0-127) where scale will begin.
+-- @tparam string scale_type String defining scale type (eg, "major", "aeolian" or "neapolitan major"), see class for full list.
+-- @tparam[opt] integer octaves Number of octaves to return, defaults to 1.
+-- @treturn {integer...} Array of MIDI note numbers.
+function MusicUtil.generate_scale(root_num, scale_type, octaves)
+  if type(root_num) ~= "number" or root_num < 0 or root_num > 127 then return nil end
+  scale_type = scale_type or 1
+  octaves = octaves or 1
+  
+  local scale_data = lookup_data(MusicUtil.SCALES, scale_type)
+  if not scale_data then return nil end
+  local length = octaves * #scale_data.intervals - (util.round(octaves) - 1)
+  
+  return generate_scale_array(root_num, scale_data, length)
+end
+
+--- Generate given number of notes of a scale from a root note.
+-- @tparam integer root_num MIDI note number (0-127) where scale will begin.
+-- @tparam integer scale_type String defining scale type (eg, "major", "aeolian" or "neapolitan major"), see class for full list.
+-- @tparam integer length Number of notes to return, defaults to 8.
+-- @treturn {integer...} Array of MIDI note numbers.
+function MusicUtil.generate_scale_of_length(root_num, scale_type, length)
+  length = length or 8
+  
+  local scale_data = lookup_data(MusicUtil.SCALES, scale_type)
+  if not scale_data then return nil end
+  
+  return generate_scale_array(root_num, scale_data, length)
+end
+
+
+--- Generate chord from a root note.
+-- @tparam integer root_num MIDI note number (0-127) for chord.
+-- @tparam string chord_type String defining chord type (eg, "major", "minor 7" or "sus4"), see class for full list.
+-- @tparam[opt] integer inversion Number of chord inversion.
+-- @treturn {integer...} Array of MIDI note numbers.
+function MusicUtil.generate_chord(root_num, chord_type, inversion)
+  if type(root_num) ~= "number" or root_num < 0 or root_num > 127 then return nil end
+  chord_type = chord_type or 1
+  inversion = inversion or 0
+  
+  local chord_data = lookup_data(MusicUtil.CHORDS, chord_type)
+  if not chord_data then return nil end
+
+  local out_array = {}
+  for i = 1, #chord_data.intervals do
+    local note_num = root_num + chord_data.intervals[i]
+    if note_num > 127 then break end
+    table.insert(out_array, note_num)
+  end
+
+  for i = 1, util.clamp(inversion, 0, #out_array - 1) do
+    local head = table.remove(out_array, 1)
+    table.insert(out_array, head + 12)
+  end
+
+  return out_array
+end
+
+--- Generate chord from a root note.
+-- @tparam integer root_num MIDI note number (0-127) defining the key.
+-- @tparam string scale_type String defining scale type (eg, "major", "dorian"), see class for full list.
+-- @tparam string roman_chord_type Roman-numeral-style string defining chord type (eg, "V", "iv7" or "III+")
+--    including limited bass notes (e.g. "iv6-9") and lowercase-letter inversion notation (e.g. "IIb" for first inversion)
+--    Will only return chords defined in MusicUtil.CHORDS.
+-- @treturn {integer...} Array of MIDI note numbers.
+function MusicUtil.generate_chord_roman(root_num, scale_type, roman_chord_type)
+
+  if type(root_num) ~= "number" or root_num < 0 or root_num > 127 then return nil end
+  local rct = roman_chord_type or "I"
+
+  local scale_data = lookup_data(MusicUtil.SCALES, scale_type)
+  if not scale_data then return nil end
+
+  -- treat extended ascii degree symbols as asterisks
+  rct = string.gsub(rct, "\u{B0}", "*")
+  rct = string.gsub(rct, "\u{BA}", "*")
+
+  local degree_string, augdim_string, added_string, bass_string, inv_string =
+    string.match(rct, "([ivxIVX]+)([+*]?)([0-9]*)-?([0-9]?)([bcdefg]?)")
+
+  local d = string.lower(degree_string)
+  local is_major = degree_string ~= d
+  local is_augmented = augdim_string == "+"
+  local is_diminished = augdim_string == "*"
+  local is_seventh = added_string == "7"
+
+  local chord_type = nil
+  if is_major then
+    if is_augmented then
+      if is_seventh then
+        chord_type = "Augmented 7"
+      else
+        chord_type = "Augmented"
+      end
+    elseif is_diminished then
+      if is_seventh then
+        chord_type = "Diminished 7"
+      else
+        chord_type = "Diminished"
+      end
+    elseif added_string == "6" then
+      if bass_string == "9" then
+        chord_type = "Major 69"
+      else
+        chord_type = "Major 6"
+      end
+    elseif is_seventh then
+      chord_type = "Major 7"
+    elseif added_string == "9" then
+      chord_type = "Major 9"
+    elseif added_string == "11" then
+      chord_type = "Major 11"
+    elseif added_string == "13" then
+      chord_type = "Major 13"
+    else
+      chord_type = "Major"
+    end
+  else -- minor
+    if is_augmented then
+      if is_seventh then
+        chord_type = "Augmented 7"
+      else
+        chord_type = "Augmented"
+      end
+    elseif is_diminished then
+      if is_seventh then
+        chord_type = "Diminished 7"
+      else
+        chord_type = "Diminished"
+      end
+    elseif added_string == "6" then
+      if bass_string == "9" then
+        chord_type = "Minor 69"
+      else
+        chord_type = "Minor 6"
+      end
+    elseif is_seventh then
+      chord_type = "Minor 7"
+    elseif added_string == "9" then
+      chord_type = "Minor 9"
+    elseif added_string == "11" then
+      chord_type = "Minor 11"
+    elseif added_string == "13" then
+      chord_type = "Minor 13"
+    else
+      chord_type = "Minor"
+    end
+  end
+
+  local degree = nil
+  local roman_numerals = { "i", "ii", "iii", "iv", "v", "vi", "vii" }
+  for i,v in pairs(roman_numerals) do
+    if(v == d) then
+      degree = i
+      break
+    end
+  end
+  if degree == nil then return nil end
+
+  local inv = string.lower(inv_string)
+  local inversion = 0
+  local inversioncodes = { "b", "c", "d", "e", "f", "g" }
+  for i,v in pairs(inversioncodes) do
+    if(v == inv) then
+      inversion = i
+      break
+    end
+  end
+
+  local degree_note = root_num + scale_data.intervals[degree]
+
+  return MusicUtil.generate_chord(degree_note, chord_type, inversion)
+end
+
+--- Generate chord from a root note.
+-- @tparam integer root_num MIDI note number (0-127) defining the key.
+-- @tparam string scale_type String defining scale type (eg, "major", "dorian"), see class for full list.
+-- @tparam integer degree Number between 1-7 selecting the degree of the chord.
+--    See MusicUtil.SCALE_CHORD_DEGREES for chords assigned to each degree.
+--    Will only return chords defined in MusicUtil.CHORDS.
+-- @tparam[opt] boolean seventh Return the 7th chord if set to true (optional)
+-- @treturn {integer...} Array of MIDI note numbers.
+function MusicUtil.generate_chord_scale_degree(root_num, scale_type, degree, seventh)
+  local d = util.clamp(degree, 1, 7)
+  if seventh then d = d + 7 end
+  local scale_data = lookup_data(MusicUtil.SCALE_CHORD_DEGREES, scale_type)
+  return MusicUtil.generate_chord_roman(root_num, scale_type, scale_data.chords[d])
+end
+
+--- List chord types for a given root note and key.
+-- @tparam integer note_num MIDI note number (0-127) for root of chord.
+-- @tparam integer key_root MIDI note number (0-127) for root of key.
+-- @tparam string key_type String defining key type (eg, "major", "aeolian" or "neapolitan major"), see class for full list.
+-- @treturn {string...} Array of chord type strings that fit the criteria.
+function MusicUtil.chord_types_for_note(note_num, key_root, key_type)
+
+  if type(key_root) ~= "number" or key_root < 0 or key_root > 127 then return nil end
+  key_type = key_type or 1
+  local scale_data = lookup_data(MusicUtil.SCALES, key_type)
+  if not scale_data then return nil end
+
+  local position_in_scale
+  for i = 1, #scale_data.intervals do
+    if scale_data.intervals[i] == (note_num - key_root) % 12 then
+      position_in_scale = i
+      break
+    end
+  end
+
+  local out_array = {}
+  if position_in_scale then
+    for i = 1, #scale_data.chords[position_in_scale] do
+      table.insert(out_array, MusicUtil.CHORDS[scale_data.chords[position_in_scale][i]].name)
+    end
+  end
+  return out_array
+end
+
+
+--- Snap a MIDI note number to the nearest note number in an array.
+-- @tparam integer note_num MIDI note number input (0-127).
+-- @tparam {integer...} snap_array Array of MIDI note numbers to snap to, must be in low to high order.
+-- @treturn integer Adjusted note number.
+function MusicUtil.snap_note_to_array(note_num, snap_array)
+  local snap_array_len = #snap_array
+  if snap_array_len == 1 then
+    note_num = snap_array[1]
+  elseif note_num >= snap_array[snap_array_len] then
+    note_num = snap_array[snap_array_len]
+  else
+    local delta
+    local prev_delta = math.huge
+    for s = 1, snap_array_len + 1 do
+      if s > snap_array_len then
+        note_num = note_num + prev_delta
+        break
+      end
+      delta = snap_array[s] - note_num
+      if delta == 0 then
+        break
+      elseif math.abs(delta) >= math.abs(prev_delta) then
+        note_num = note_num + prev_delta
+        break
+      end
+      prev_delta = delta
+    end
+  end
+
+  return note_num
+end
+
+--- Snap an array of MIDI note numbers to an array of note numbers.
+-- @tparam {integer...} note_nums_array Array of input MIDI note numbers.
+-- @tparam {integer...} snap_array Array of MIDI note numbers to snap to, must be in low to high order.
+-- @treturn {integer...} Array of adjusted note numbers.
+function MusicUtil.snap_notes_to_array(note_nums_array, snap_array)
+  for i = 1, #note_nums_array do
+    note_nums_array[i] = MusicUtil.snap_note_to_array(note_nums_array[i], snap_array)
+  end
+  return note_nums_array
+end
+
+
+--- Return a MIDI note number's note name.
+-- @tparam integer note_num MIDI note number (0-127).
+-- @tparam[opt] boolean include_octave Include octave number in return string if set to true.
+-- @treturn string Name string (eg, "C#3").
+function MusicUtil.note_num_to_name(note_num, include_octave)
+  local name = MusicUtil.NOTE_NAMES[note_num % 12 + 1]
+  if include_octave then name = name .. math.floor(note_num / 12 - 2) end
+  return name
+end
+
+--- Return an array of MIDI note numbers' names.
+-- @tparam {integer...} note_nums_array Array of MIDI note numbers.
+-- @tparam[opt] boolean include_octave Include octave number in return strings if set to true.
+-- @treturn {string...} Array of name strings.
+function MusicUtil.note_nums_to_names(note_nums_array, include_octave)
+  local out_array = {}
+  for i = 1, #note_nums_array do
+    out_array[i] = MusicUtil.note_num_to_name(note_nums_array[i], include_octave)
+  end
+  return out_array
+end
+
+
+--- Return a MIDI note number's frequency.
+-- @tparam integer note_num MIDI note number (0-127).
+-- @treturn float Frequency number in Hz.
+function MusicUtil.note_num_to_freq(note_num)
+  return 13.75 * (2 ^ ((note_num - 9) / 12))
+end
+
+--- Return an array of MIDI note numbers' frequencies.
+-- @tparam {integer...} note_nums_array Array of MIDI note numbers.
+-- @treturn {float...} Array of frequency numbers in Hz.
+function MusicUtil.note_nums_to_freqs(note_nums_array)
+  local out_array = {}
+  for i = 1, #note_nums_array do
+    out_array[i] = MusicUtil.note_num_to_freq(note_nums_array[i])
+  end
+  return out_array
+end
+
+
+--- Return a frequency's nearest MIDI note number.
+-- @tparam float freq Frequency number in Hz.
+-- @treturn integer MIDI note number (0-127).
+function MusicUtil.freq_to_note_num(freq)
+  return util.clamp(math.floor(12 * math.log(freq / 440.0) / math.log(2) + 69.5), 0, 127)
+end
+
+--- Return an array of frequencies' nearest MIDI note numbers.
+-- @tparam {float...} freqs_array Array of frequency numbers in Hz.
+-- @treturn {integer...} Array of MIDI note numbers.
+function MusicUtil.freqs_to_note_nums(freqs_array)
+  local out_array = {}
+  for i = 1, #freqs_array do
+    out_array[i] = MusicUtil.freq_to_note_num(freqs_array[i])
+  end
+  return out_array
+end
+
+
+--- Return the ratio of an interval.
+-- @tparam float interval Interval in semitones.
+-- @treturn float Ratio number.
+function MusicUtil.interval_to_ratio(interval)
+  return math.pow(2, interval / 12)
+end
+
+--- Return an array of ratios of intervals.
+-- @tparam {float...} intervals_array Array of intervals in semitones.
+-- @treturn {float...} Array of ratio numbers.
+function MusicUtil.intervals_to_ratios(intervals_array)
+  local out_array = {}
+  for i = 1, #intervals_array do
+    out_array[i] = MusicUtil.interval_to_ratio(intervals_array[i])
+  end
+  return out_array
+end
+
+--- Return the interval of a ratio.
+-- @tparam float ratio Ratio number.
+-- @treturn float Interval in semitones.
+function MusicUtil.ratio_to_interval(ratio)
+  return 12 * math.log(ratio) / math.log(2)
+end
+
+--- Return an array of intervals of ratios.
+-- @tparam {float...} ratios_array Array of ratio numbers.
+-- @treturn {float...} Array of intervals in semitones.
+function MusicUtil.ratios_to_intervals(ratios_array)
+  local out_array = {}
+  for i = 1, #ratios_array do
+    out_array[i] = MusicUtil.ratio_to_interval(ratios_array[i])
+  end
+  return out_array
+end
+
+
+return MusicUtil

--- a/lua/lib/pattern_time.lua
+++ b/lua/lib/pattern_time.lua
@@ -1,0 +1,151 @@
+--- timed pattern event recorder/player
+-- @module lib.pattern
+
+local pattern = {}
+pattern.__index = pattern
+
+--- constructor
+function pattern.new()
+  local i = {}
+  setmetatable(i, pattern)
+  i.rec = 0
+  i.play = 0
+  i.overdub = 0
+  i.prev_time = 0
+  i.event = {}
+  i.time = {}
+  i.count = 0
+  i.step = 0
+  i.time_factor = 1
+
+  i.metro = metro.init(function() i:next_event() end,1,1)
+
+  i.process = function(_) print("event") end
+
+  return i
+end
+
+--- clear this pattern
+function pattern:clear()
+  self.metro:stop()
+  self.rec = 0
+  self.play = 0
+  self.overdub = 0
+  self.prev_time = 0
+  self.event = {}
+  self.time = {}
+  self.count = 0
+  self.step = 0
+  self.time_factor = 1
+end
+
+--- adjust the time factor of this pattern.
+-- @tparam number f time factor
+function pattern:set_time_factor(f)
+  self.time_factor = f or 1
+end
+
+--- start recording
+function pattern:rec_start()
+  print("pattern rec start")
+  self.rec = 1
+end
+
+--- stop recording
+function pattern:rec_stop()
+  if self.rec == 1 then
+    self.rec = 0
+    if self.count ~= 0 then
+      --print("count "..self.count)
+      local t = self.prev_time
+      self.prev_time = util.time()
+      self.time[self.count] = self.prev_time - t
+      --tab.print(self.time)
+    else
+      print("pattern_time: no events recorded")
+    end 
+  else print("pattern_time: not recording")
+  end
+end
+
+--- watch
+function pattern:watch(e)
+  if self.rec == 1 then
+    self:rec_event(e)
+  elseif self.overdub == 1 then
+    self:overdub_event(e)
+  end
+end
+
+--- record event
+function pattern:rec_event(e)
+  local c = self.count + 1
+  if c == 1 then
+    self.prev_time = util.time()
+  else
+    local t = self.prev_time
+    self.prev_time = util.time()
+    self.time[c-1] = self.prev_time - t
+  end
+  self.count = c
+  self.event[c] = e
+end
+
+--- add overdub event
+function pattern:overdub_event(e)
+  local c = self.step + 1
+  local t = self.prev_time
+  self.prev_time = util.time()
+  local a = self.time[c-1]
+  self.time[c-1] = self.prev_time - t
+  table.insert(self.time, c, a - self.time[c-1])
+  table.insert(self.event, c, e)
+  self.step = self.step + 1
+  self.count = self.count + 1
+end
+
+--- start this pattern
+function pattern:start()
+  if self.count > 0 then
+    --print("start pattern ")
+    self.prev_time = util.time()
+    self.process(self.event[1])
+    self.play = 1
+    self.step = 1
+    self.metro.time = self.time[1] * self.time_factor
+    self.metro:start()
+  end
+end
+
+--- process next event
+function pattern:next_event()
+  self.prev_time = util.time()
+  if self.step == self.count then self.step = 1
+  else self.step = self.step + 1 end
+  --print("next step "..self.step)
+  --event_exec(self.event[self.step])
+  self.process(self.event[self.step])
+  self.metro.time = self.time[self.step] * self.time_factor
+  --print("next time "..self.metro.time)
+  self.metro:start()
+end
+
+--- stop this pattern
+function pattern:stop()
+  if self.play == 1 then
+    self.play = 0
+    self.overdub = 0
+    self.metro:stop()
+  else print("pattern_time: not playing") end
+end
+
+--- set overdub
+function pattern:set_overdub(s)
+  if s==1 and self.play == 1 and self.rec == 0 then
+    self.overdub = 1
+  else
+    self.overdub = 0
+  end
+end
+
+return pattern

--- a/lua/lib/sequins.lua
+++ b/lua/lib/sequins.lua
@@ -1,0 +1,292 @@
+--- sequins
+
+local S = {}
+
+-- convert a string to a table of chars
+local function totable(t)
+    if type(t) == 'string' then
+        local tmp = {}
+        t:gsub('.', function(c) table.insert(tmp,c) end)
+        return tmp
+    end
+    return t
+end
+
+function S.new(t)
+    t = totable(t) -- convert a string to a table of chars
+    -- wrap a table in a sequins with defaults
+    local s = { data   = t
+              , length = #t -- memoize for efficiency
+              , ix     = 1
+              , qix    = 1 -- force 1st value to 1st step
+              , n      = 1 -- store the step val (can be a sequins)
+              , flw    = {} -- store any applied flow modifiers
+              , fun    = {} -- store a transformer function & any additional arguments
+              }
+    return setmetatable(s, S)
+end
+
+local function wrap_index(s, ix) return ((ix - 1) % s.length) + 1 end
+
+function S:is_sequins() return getmetatable(self) == S end
+
+function S:setdata(t)
+    if S.is_sequins(t) then
+        do -- flow modifiers
+            local src = t.flw
+            local dst = self.flw
+
+            -- update / remove existing
+            for k,v in pairs(dst) do
+                if src[k] then -- already exists
+                    dst[k].n  = src[k].n -- update value
+                else dst[k] = nil end -- removed
+            end
+
+            -- add any new
+            for k,v in pairs(src) do
+                if not dst[k] then -- newly added
+                    dst[k] = {ix = v.ix, n = v.n} -- manual copy
+                end
+            end
+        end
+
+        do -- update data of transformers
+            local src = t.fun
+            local dst = self.fun
+
+            if dst[1] then -- already have a transformer
+                dst[1] = src[1] -- copy function
+                if src[2] then
+                    for k,v in ipairs(src[2]) do
+                         if S.is_sequins(v) and dst[2] and S.is_sequins(dst[2][k]) then
+                            dst[2][k]:settable(v) -- recurse nested sequins
+                        else
+                            dst[2][k] = v -- copy piecemeal
+                        end
+                    end
+                end
+            elseif src[1] then -- no existing transformer, so we just pull in the new one
+                print'new transformer'
+                self.fun = t.fun
+            end
+        end
+
+        -- finally, place data over top of input sequins
+        t = t.data -- handle sequins data as input table
+    end
+
+    t = totable(t) -- convert a string to a table of chars
+
+    -- data swap
+    for i=1,#t do
+        if S.is_sequins(t[i]) and S.is_sequins(self.data[i]) then
+            self.data[i]:settable(t[i]) -- recurse nested sequins
+        else
+            self.data[i] = t[i] -- copy table piecemeal
+        end
+    end
+    self.data[#t+1] = nil -- disregard any surplus data
+
+    self.length = #t
+    self.ix = wrap_index(self, self.ix)
+end
+
+function S:copy()
+    if type(self) == 'table' then
+        local cp = {}
+        for k,v in pairs(self) do
+            cp[k] = S.copy(v)
+        end
+        return setmetatable(cp, getmetatable(self))
+    else return self end
+end
+
+function S:peek() return self.data[self.ix] end
+
+function S:bake(n)
+    n = n or #self -- void call creates a table of length == the parent sequins
+    local t = {}
+    for i=1,n do
+        t[i] = self()
+    end
+    return S.new(t)
+end
+
+local function turtle(t, fn)
+    -- apply fn to all nested sequins
+    fn = fn or S.next -- default to S.next
+    if S.is_sequins(t) then return fn(t) end -- unwrap
+    return t -- literal value
+end
+
+------------------------------
+--- transformers
+
+function S:func(fn, ...)
+    self.fun = {fn, {...}} -- capture function & any args (sequins)
+    return self
+end
+
+local function do_transform(s, v)
+    if s.fun[1] then -- implicitly handles a cleared function
+        if #s.fun[2] > 0 then
+            return s.fun[1](v, table.unpack(s.fun[2]))
+        else return s.fun[1](v) end
+    else return v end
+end
+
+-- support arithmetic via math operators
+S._fns = {
+    add = function(n,b) return n+turtle(b) end,
+    sub = function(n,b) return n-turtle(b) end,
+    mul = function(n,b) return n*turtle(b) end,
+    div = function(n,b) return n/turtle(b) end,
+    mod = function(n,b) return n%turtle(b) end,
+}
+
+-- assume 'a' is self of a sequins
+S.__add = function(a,b) return S.func(a, S._fns.add, b) end
+S.__sub = function(a,b) return S.func(a, S._fns.sub, b) end
+S.__mul = function(a,b) return S.func(a, S._fns.mul, b) end
+S.__div = function(a,b) return S.func(a, S._fns.div, b) end
+S.__mod = function(a,b) return S.func(a, S._fns.mod, b) end
+
+------------------------------
+--- control flow execution
+
+local function do_step(s)
+    -- if .qix is set, it will be used, rather than incrementing by s.n
+    local newix = wrap_index(s, s.qix or s.ix + turtle(s.n))
+    -- pull data from new index (unwrap if it's a sequins)
+    local retval, exec = turtle(s.data[newix])
+    -- handle messaging from child sequins
+    if exec ~= 'again' then s.ix = newix; s.qix = nil end
+    -- FIXME add protection for list of dead sequins. for now we just recur, hoping for a live sequin in nest
+    if retval == 'skip' or retval == 'dead' then return S.next(s) end
+    return retval, exec
+end
+
+S.flows = {
+    every = function(f,n) return (f.ix % n) ~= 0 end,
+    times = function(f,n) return f.ix > n end,
+    count = function(f,n)
+        if f.ix < n then return 'again'
+        else f.ix = 0 end
+    end
+}
+
+local function do_flow(s, k)
+    local f = s.flw[k] -- check if flow-mod exists
+    if f then
+        f.ix = f.ix + 1
+        return S.flows[k](f, turtle(f.n))
+    end
+end
+
+function S.next(s)
+    if do_flow(s, 'every') then return 'skip' end
+    if do_flow(s, 'times') then return 'dead' end
+    local again = do_flow(s, 'count')
+    if again then
+        local e = s.flw.every
+        if e then e.ix = e.ix - 1 end -- undo every advance
+    end
+    return do_transform(s,do_step(s)), again
+end
+
+function S:step(n) self.n = n; return self end
+
+function S.flow(s, k, n) s.flw[k] = {n=n, ix=0}; return s end
+function S:every(n) return self:flow('every',n) end
+function S:count(n) return self:flow('count',n) end
+function S:times(n) return self:flow('times',n) end
+function S:all() return self:flow('count',#self) end
+
+function S:select(ix)
+    rawset(self, 'qix', ix) -- qix may be nil, hence rawset
+    return self
+end
+
+function S:reset()
+    self:select(1)
+    for _,v in ipairs(self.data) do turtle(v, S.reset) end
+    for _,v in pairs(self.flw) do
+        v.ix = 0
+        turtle(v.n, S.reset)
+    end
+    if self.fun[1] and #self.fun[2] > 0 then
+        for _,v in pairs(self.fun[2]) do
+            turtle(v, S.reset)
+        end
+    end
+end
+
+
+------------------------------
+--- metamethods
+
+-- calling the sequins library will create a new sequins object (S:new)
+-- calling a sequins object will produce a new value (S:next)
+S.__call = function(self, ...)
+    return (self == S) and S.new(...) or S.next(self)
+end
+
+S.metaix = { settable = S.setdata
+           , step     = S.step
+           , flow     = S.flow
+           , every    = S.every
+           , times    = S.times
+           , count    = S.count
+           , all      = S.all
+           , reset    = S.reset
+           , select   = S.select
+           , peek     = S.peek
+           , copy     = S.copy
+           , map      = S.func
+           , bake     = S.bake
+           }
+S.__index = function(self, ix)
+    if type(ix) == 'number' then return self.data[ix]
+    else
+        return S.metaix[ix]
+    end
+end
+
+S.__newindex = function(self, ix, v)
+    if type(ix) == 'number' then self.data[ix] = v
+    elseif ix == 'n' then rawset(self,ix,v)
+    end
+end
+
+S.__tostring = function(t)
+    -- data
+    local st = {}
+    for i=1,t.length do
+        st[i] = tostring(t.data[i])
+    end
+    local s = string.format('s[%i]{%s}', t.qix or t.ix, table.concat(st,','))
+
+    -- modifiers
+    for k,v in pairs(t.flw) do
+        -- TODO do we need to print current counters?
+        s = string.format('%s:%s[%i](%s)',s, k:sub(1,1), v.ix, tostring(v.n))
+    end
+
+    -- transformer
+    if #t.fun > 0 then
+        local fns = {'fn'}
+        for i=1,#t.fun[2] do
+            fns[i+1] = tostring(t.fun[2][i])
+        end
+        s = string.format('%s:map(%s)',s, table.concat(fns, ','))
+    end
+
+    return s
+end
+
+-- use memoized data length, aka #(t.data)
+S.__len = function(t) return t.length end
+
+
+return setmetatable(S, S)

--- a/lua/lib/tabutil.lua
+++ b/lua/lib/tabutil.lua
@@ -1,17 +1,19 @@
 --- table utility
--- @module tab
-local Tab = {}
+-- @module lib.tabutil
+-- @alias tab
+
+local tab = {}
 
 --- print the contents of a table
 -- @tparam table t table to print
-Tab.print = function(t)
+tab.print = function(t)
   for k,v in pairs(t) do print(k .. '\t' .. tostring(v)) end
 end
 
 --- return a lexigraphically sorted array of keys for a table
 -- @tparam table t table to sort
 -- @treturn table sorted table
-Tab.sort = function(t)
+tab.sort = function(t)
   local keys = {}
   for k in pairs(t) do table.insert(keys, k) end
   table.sort(keys)
@@ -22,7 +24,7 @@ end
 -- unlike table.getn() or #table, nil entries won't break the loop
 -- @tparam table t table to count
 -- @treturn number count
-Tab.count = function(t)
+tab.count = function(t)
   local c = 0
   for _ in pairs(t) do c = c + 1 end
   return c
@@ -32,18 +34,19 @@ end
 -- @tparam table t table to check
 -- @param e element to look for
 -- @treturn boolean t/f is element is present
-Tab.contains = function(t,e)
+tab.contains = function(t,e)
   for index, value in ipairs(t) do
     if value == e then return true end
   end
   return false
 end
 
+
 --- given a simple table of primitives, 
 --- "invert" it so that values become keys and vice versa.
 --- this allows more efficient checks on multiple values
--- @param t a simple table
-Tab.invert = function(t)
+-- @param t: a simple table
+tab.invert = function(t)
   local inv = {}
   for k,v in pairs(t) do
     inv[v] = k
@@ -51,11 +54,12 @@ Tab.invert = function(t)
   return inv
 end
 
+
 --- search table for element, return key
 -- @tparam table t table to check
 -- @param e element to look for
 -- @return key, nil if not found
-Tab.key = function(t,e)
+tab.key = function(t,e)
   for index, value in ipairs(t) do
     if value == e then return index end
   end
@@ -65,7 +69,7 @@ end
 --- split multi-line string into table of strings
 -- @tparam string str string with line breaks
 -- @treturn table table with entries for each line
-Tab.lines = function(str)
+tab.lines = function(str)
   local t = {}
   local function helper(line)
     table.insert(t, line)
@@ -75,10 +79,11 @@ Tab.lines = function(str)
   return t
 end
 
+
 --- split string into table with delimiter
 -- @tparam string inputstr : string to split
 -- @tparam string sep : delimiter
-Tab.split = function(inputstr, sep)
+tab.split = function(inputstr, sep)
 	if sep == nil then
 		sep = "%s"
 	end
@@ -89,4 +94,190 @@ Tab.split = function(inputstr, sep)
 	return t
 end
 
-return Tab
+
+--- Save a table to disk.
+-- Saves tables, numbers, booleans and strings.
+-- Inside table references are saved.
+-- Does not save userdata, metatables, functions and indices of these.
+-- Based on http://lua-users.org/wiki/SaveTableToFile by ChillCode.
+-- @tparam table tbl Table to save.
+-- @tparam string filename Location to save to.
+-- @return On failure, returns an error msg.
+function tab.save(tbl, filename)
+  local charS, charE = "   ", "\n"
+  local file, err = io.open(filename, "wb")
+  if err then return err end
+
+  -- initiate variables for save procedure
+  local tables, lookup = { tbl }, { [tbl] = 1 }
+  file:write("return {"..charE)
+
+  for idx, t in ipairs(tables) do
+    file:write("-- Table: {"..idx.."}"..charE)
+    file:write("{"..charE)
+    local thandled = {}
+
+    for i, v in ipairs(t) do
+      thandled[i] = true
+      local stype = type(v)
+      -- only handle value
+      if stype == "table" then
+        if not lookup[v] then
+          table.insert(tables, v)
+          lookup[v] = #tables
+        end
+        file:write(charS.."{"..lookup[v].."},"..charE)
+      elseif stype == "string" then
+        file:write(charS..string.format("%q", v)..","..charE)
+      elseif stype == "number" then
+        file:write(charS..tostring(v)..","..charE)
+      elseif stype == "boolean" then
+        file:write(charS..tostring(v)..","..charE)
+      end
+    end
+
+    for i, v in pairs(t) do
+      -- escape handled values
+      if (not thandled[i]) then
+
+        local str = ""
+        local stype = type(i)
+        -- handle index
+        if stype == "table" then
+          if not lookup[i] then
+             table.insert(tables, i)
+             lookup[i] = #tables
+          end
+          str = charS.."[{"..lookup[i].."}]="
+        elseif stype == "string" then
+          str = charS.."["..string.format("%q", i).."]="
+        elseif stype == "number" then
+          str = charS.."["..tostring(i).."]="
+        elseif stype == "boolean" then
+          str = charS.."["..tostring(i).."]="
+        end
+
+        if str ~= "" then
+          stype = type(v)
+          -- handle value
+          if stype == "table" then
+            if not lookup[v] then
+              table.insert(tables, v)
+              lookup[v] = #tables
+            end
+            file:write(str.."{"..lookup[v].."},"..charE)
+          elseif stype == "string" then
+            file:write(str..string.format("%q", v)..","..charE)
+          elseif stype == "number" then
+            file:write(str..tostring(v)..","..charE)
+          elseif stype == "boolean" then
+            file:write(str..tostring(v)..","..charE)
+          end
+        end
+      end
+    end
+    file:write("},"..charE)
+  end
+  file:write("}")
+  file:close()
+end
+
+--- Load a table that has been saved via the tab.save() function.
+-- @tparam string sfile Filename or stringtable to load.
+-- @return On success, returns a previously saved table. On failure, returns as second argument an error msg.
+function tab.load(sfile)
+  local ftables,err = loadfile(sfile)
+  if err then return _, err end
+  local tables = ftables()
+  for idx = 1, #tables do
+    local tolinki = {}
+    for i, v in pairs(tables[idx]) do
+      if type(v) == "table" then
+        tables[idx][i] = tables[v[1]]
+      end
+      if type(i) == "table" and tables[i[1]] then
+        table.insert(tolinki, { i, tables[i[1]] })
+      end
+    end
+    -- link indices
+    for _, v in ipairs(tolinki) do
+      tables[idx][v[2]], tables[idx][v[1]] =  tables[idx][v[1]], nil
+    end
+  end
+  return tables[1]
+end
+
+--- Create a read-only proxy for a given table.
+-- @param params params.table is the table to proxy, params.except a list of writable keys, params.expose limits which keys from params.table are exposed (optional)
+-- @treturn table the proxied read-only table
+function tab.readonly(params)
+  local t = params.table
+  local exceptions = params.except or {}
+  local proxy = {}
+  local mt = {
+    __index = function(_, k)
+      if params.expose == nil or tab.contains(params.expose, k) then
+        return t[k]
+      end
+      return nil
+    end,
+    __newindex = function (_,k,v)
+      if (tab.contains(exceptions, k)) then
+        t[k] = v
+      else
+        error("'"..k.."', a read-only key, cannot be re-assigned.")
+      end
+    end,
+    __pairs = function (_) return pairs(proxy) end,
+    __ipairs = function (_) return ipairs(proxy) end,
+  }
+  setmetatable(proxy, mt)
+  return proxy
+end
+
+
+--- return new table, gathering values:
+--- - first from default_values, 
+--- - then from (i.e. overridden by) custom_values
+--- nils in custom_values are ignored
+-- @tparam table default_values base values (provides keys & fallback values)
+-- @tparam table custom_values override values (take precedence)
+-- @treturn table composite table
+function tab.gather(default_values, custom_values)
+  local result = {}
+  for k,v in pairs(default_values) do 
+    result[k] = (custom_values[k] ~= nil) and custom_values[k] or v
+  end
+  return result
+end
+
+--- mutate first table, updating values from second table.
+--- new keys from second table will be added to first.
+--- nils in updated_values are ignored
+-- @tparam table table_to_mutate table to mutate
+-- @tparam table updated_values override values (take precedence)
+-- @treturn table composite table
+function tab.update(table_to_mutate, updated_values)
+  for k,v in pairs(updated_values) do 
+    if updated_values[k] ~= nil then
+      table_to_mutate[k] = updated_values[k]
+    end
+  end
+  return table_to_mutate
+end
+
+--- Create a new table with all values that pass the test implemented by the provided function.
+-- @tparam table t table to check
+-- @param condition callback function that tests all values of provided table, passes value and key as arguments
+-- @treturn table table with values that pass the test
+tab.select_values = function(tbl, condition)
+  local t = {}
+
+  for k,v in pairs(tbl) do
+    if condition(v,k) then t[k] = v end
+  end
+
+  return t
+end
+
+return tab

--- a/lua/lib/test/luaunit.lua
+++ b/lua/lib/test/luaunit.lua
@@ -1,0 +1,3044 @@
+--[[
+        luaunit.lua
+
+Description: A unit testing framework
+Homepage: https://github.com/bluebird75/luaunit
+Development by Philippe Fremy <phil@freehackers.org>
+Based on initial work of Ryu, Gwang (http://www.gpgstudy.com/gpgiki/LuaUnit)
+License: BSD License, see LICENSE.txt
+]]--
+
+require("math")
+local M={}
+
+-- private exported functions (for testing)
+M.private = {}
+
+M.VERSION='3.3'
+M._VERSION=M.VERSION -- For LuaUnit v2 compatibility
+
+-- a version which distinguish between regular Lua and LuaJit
+M._LUAVERSION = (jit and jit.version) or _VERSION
+
+--[[ Some people like assertEquals( actual, expected ) and some people prefer
+assertEquals( expected, actual ).
+]]--
+M.ORDER_ACTUAL_EXPECTED = true
+M.PRINT_TABLE_REF_IN_ERROR_MSG = false
+M.TABLE_EQUALS_KEYBYCONTENT = true
+M.LINE_LENGTH = 80
+M.TABLE_DIFF_ANALYSIS_THRESHOLD = 10    -- display deep analysis for more than 10 items
+M.LIST_DIFF_ANALYSIS_THRESHOLD  = 10    -- display deep analysis for more than 10 items
+
+--[[ EPS is meant to help with Lua's floating point math in simple corner
+cases like almostEquals(1.1-0.1, 1), which may not work as-is (e.g. on numbers
+with rational binary representation) if the user doesn't provide some explicit
+error margin.
+
+The default margin used by almostEquals() in such cases is EPS; and since
+Lua may be compiled with different numeric precisions (single vs. double), we
+try to select a useful default for it dynamically. Note: If the initial value
+is not acceptable, it can be changed by the user to better suit specific needs.
+
+See also: https://en.wikipedia.org/wiki/Machine_epsilon
+]]
+M.EPS = 2^-52 -- = machine epsilon for "double", ~2.22E-16
+if math.abs(1.1 - 1 - 0.1) > M.EPS then
+    -- rounding error is above EPS, assume single precision
+    M.EPS = 2^-23 -- = machine epsilon for "float", ~1.19E-07
+end
+
+-- set this to false to debug luaunit
+local STRIP_LUAUNIT_FROM_STACKTRACE = true
+
+M.VERBOSITY_DEFAULT = 10
+M.VERBOSITY_LOW     = 1
+M.VERBOSITY_QUIET   = 0
+M.VERBOSITY_VERBOSE = 20
+M.DEFAULT_DEEP_ANALYSIS = nil
+M.FORCE_DEEP_ANALYSIS   = true
+M.DISABLE_DEEP_ANALYSIS = false
+
+-- set EXPORT_ASSERT_TO_GLOBALS to have all asserts visible as global values
+-- EXPORT_ASSERT_TO_GLOBALS = true
+
+-- we need to keep a copy of the script args before it is overriden
+local cmdline_argv = rawget(_G, "arg")
+
+M.FAILURE_PREFIX = 'LuaUnit test FAILURE: ' -- prefix string for failed tests
+M.SUCCESS_PREFIX = 'LuaUnit test SUCCESS: ' -- prefix string for successful tests finished early
+
+
+
+M.USAGE=[[Usage: lua <your_test_suite.lua> [options] [testname1 [testname2] ... ]
+Options:
+  -h, --help:             Print this help
+  --version:              Print version information
+  -v, --verbose:          Increase verbosity
+  -q, --quiet:            Set verbosity to minimum
+  -e, --error:            Stop on first error
+  -f, --failure:          Stop on first failure or error
+  -s, --shuffle:          Shuffle tests before running them
+  -o, --output OUTPUT:    Set output type to OUTPUT
+                          Possible values: text, tap, junit, nil
+  -n, --name NAME:        For junit only, mandatory name of xml file
+  -r, --repeat NUM:       Execute all tests NUM times, e.g. to trig the JIT
+  -p, --pattern PATTERN:  Execute all test names matching the Lua PATTERN
+                          May be repeated to include several patterns
+                          Make sure you escape magic chars like +? with %
+  -x, --exclude PATTERN:  Exclude all test names matching the Lua PATTERN
+                          May be repeated to exclude several patterns
+                          Make sure you escape magic chars like +? with %
+  testname1, testname2, ... : tests to run in the form of testFunction,
+                              TestClass or TestClass.testMethod
+]]
+
+local is_equal -- defined here to allow calling from mismatchFormattingPureList
+
+----------------------------------------------------------------
+--
+--                 general utility functions
+--
+----------------------------------------------------------------
+
+local function pcall_or_abort(func, ...)
+    -- unpack is a global function for Lua 5.1, otherwise use table.unpack
+    local unpack = rawget(_G, "unpack") or table.unpack
+    local result = {pcall(func, ...)}
+    if not result[1] then
+        -- an error occurred
+        print(result[2]) -- error message
+        print()
+        print(M.USAGE)
+        os.exit(-1)
+    end
+    return unpack(result, 2)
+end
+
+local crossTypeOrdering = {
+    number = 1, boolean = 2, string = 3, table = 4, other = 5
+}
+local crossTypeComparison = {
+    number = function(a, b) return a < b end,
+    string = function(a, b) return a < b end,
+    other = function(a, b) return tostring(a) < tostring(b) end,
+}
+
+local function crossTypeSort(a, b)
+    local type_a, type_b = type(a), type(b)
+    if type_a == type_b then
+        local func = crossTypeComparison[type_a] or crossTypeComparison.other
+        return func(a, b)
+    end
+    type_a = crossTypeOrdering[type_a] or crossTypeOrdering.other
+    type_b = crossTypeOrdering[type_b] or crossTypeOrdering.other
+    return type_a < type_b
+end
+
+local function __genSortedIndex( t )
+    -- Returns a sequence consisting of t's keys, sorted.
+    local sortedIndex = {}
+
+    for key,_ in pairs(t) do
+        table.insert(sortedIndex, key)
+    end
+
+    table.sort(sortedIndex, crossTypeSort)
+    return sortedIndex
+end
+M.private.__genSortedIndex = __genSortedIndex
+
+local function sortedNext(state, control)
+    -- Equivalent of the next() function of table iteration, but returns the
+    -- keys in sorted order (see __genSortedIndex and crossTypeSort).
+    -- The state is a temporary variable during iteration and contains the
+    -- sorted key table (state.sortedIdx). It also stores the last index (into
+    -- the keys) used by the iteration, to find the next one quickly.
+    local key
+
+    --print("sortedNext: control = "..tostring(control) )
+    if control == nil then
+        -- start of iteration
+        state.count = #state.sortedIdx
+        state.lastIdx = 1
+        key = state.sortedIdx[1]
+        return key, state.t[key]
+    end
+
+    -- normally, we expect the control variable to match the last key used
+    if control ~= state.sortedIdx[state.lastIdx] then
+        -- strange, we have to find the next value by ourselves
+        -- the key table is sorted in crossTypeSort() order! -> use bisection
+        local lower, upper = 1, state.count
+        repeat
+            state.lastIdx = math.modf((lower + upper) / 2)
+            key = state.sortedIdx[state.lastIdx]
+            if key == control then
+                break -- key found (and thus prev index)
+            end
+            if crossTypeSort(key, control) then
+                -- key < control, continue search "right" (towards upper bound)
+                lower = state.lastIdx + 1
+            else
+                -- key > control, continue search "left" (towards lower bound)
+                upper = state.lastIdx - 1
+            end
+        until lower > upper
+        if lower > upper then -- only true if the key wasn't found, ...
+            state.lastIdx = state.count -- ... so ensure no match in code below
+        end
+    end
+
+    -- proceed by retrieving the next value (or nil) from the sorted keys
+    state.lastIdx = state.lastIdx + 1
+    key = state.sortedIdx[state.lastIdx]
+    if key then
+        return key, state.t[key]
+    end
+
+    -- getting here means returning `nil`, which will end the iteration
+end
+
+local function sortedPairs(tbl)
+    -- Equivalent of the pairs() function on tables. Allows to iterate in
+    -- sorted order. As required by "generic for" loops, this will return the
+    -- iterator (function), an "invariant state", and the initial control value.
+    -- (see http://www.lua.org/pil/7.2.html)
+    return sortedNext, {t = tbl, sortedIdx = __genSortedIndex(tbl)}, nil
+end
+M.private.sortedPairs = sortedPairs
+
+-- seed the random with a strongly varying seed
+math.randomseed(os.clock()*1E11)
+
+local function randomizeTable( t )
+    -- randomize the item orders of the table t
+    for i = #t, 2, -1 do
+        local j = math.random(i)
+        if i ~= j then
+            t[i], t[j] = t[j], t[i]
+        end
+    end
+end
+M.private.randomizeTable = randomizeTable
+
+local function strsplit(delimiter, text)
+-- Split text into a list consisting of the strings in text, separated
+-- by strings matching delimiter (which may _NOT_ be a pattern).
+-- Example: strsplit(", ", "Anna, Bob, Charlie, Dolores")
+    if delimiter == "" then -- this would result in endless loops
+        error("delimiter matches empty string!")
+    end
+    local list, pos, first, last = {}, 1
+    while true do
+        first, last = text:find(delimiter, pos, true)
+        if first then -- found?
+            table.insert(list, text:sub(pos, first - 1))
+            pos = last + 1
+        else
+            table.insert(list, text:sub(pos))
+            break
+        end
+    end
+    return list
+end
+M.private.strsplit = strsplit
+
+local function hasNewLine( s )
+    -- return true if s has a newline
+    return (string.find(s, '\n', 1, true) ~= nil)
+end
+M.private.hasNewLine = hasNewLine
+
+local function prefixString( prefix, s )
+    -- Prefix all the lines of s with prefix
+    return prefix .. string.gsub(s, '\n', '\n' .. prefix)
+end
+M.private.prefixString = prefixString
+
+local function strMatch(s, pattern, start, final )
+    -- return true if s matches completely the pattern from index start to index end
+    -- return false in every other cases
+    -- if start is nil, matches from the beginning of the string
+    -- if final is nil, matches to the end of the string
+    start = start or 1
+    final = final or string.len(s)
+
+    local foundStart, foundEnd = string.find(s, pattern, start, false)
+    return foundStart == start and foundEnd == final
+end
+M.private.strMatch = strMatch
+
+local function patternFilter(patterns, expr)
+    -- Run `expr` through the inclusion and exclusion rules defined in patterns
+    -- and return true if expr shall be included, false for excluded.
+    -- Inclusion pattern are defined as normal patterns, exclusions 
+    -- patterns start with `!` and are followed by a normal pattern
+
+    -- result: nil = UNKNOWN (not matched yet), true = ACCEPT, false = REJECT
+    -- default: true if no explicit "include" is found, set to false otherwise
+    local default, result = true, nil
+
+    if patterns ~= nil then
+        for _, pattern in ipairs(patterns) do
+            local exclude = pattern:sub(1,1) == '!'
+            if exclude then
+                pattern = pattern:sub(2)
+            else
+                -- at least one include pattern specified, a match is required
+                default = false
+            end
+            -- print('pattern: ',pattern)
+            -- print('exclude: ',exclude)
+            -- print('default: ',default)
+
+            if string.find(expr, pattern) then
+                -- set result to false when excluding, true otherwise
+                result = not exclude
+            end
+        end
+    end
+
+    if result ~= nil then
+        return result
+    end
+    return default
+end
+M.private.patternFilter = patternFilter
+
+local function xmlEscape( s )
+    -- Return s escaped for XML attributes
+    -- escapes table:
+    -- "   &quot;
+    -- '   &apos;
+    -- <   &lt;
+    -- >   &gt;
+    -- &   &amp;
+
+    return string.gsub( s, '.', {
+        ['&'] = "&amp;",
+        ['"'] = "&quot;",
+        ["'"] = "&apos;",
+        ['<'] = "&lt;",
+        ['>'] = "&gt;",
+    } )
+end
+M.private.xmlEscape = xmlEscape
+
+local function xmlCDataEscape( s )
+    -- Return s escaped for CData section, escapes: "]]>"
+    return string.gsub( s, ']]>', ']]&gt;' )
+end
+M.private.xmlCDataEscape = xmlCDataEscape
+
+local function stripLuaunitTrace( stackTrace )
+    --[[
+    -- Example of  a traceback:
+    <<stack traceback:
+        example_with_luaunit.lua:130: in function 'test2_withFailure'
+        ./luaunit.lua:1449: in function <./luaunit.lua:1449>
+        [C]: in function 'xpcall'
+        ./luaunit.lua:1449: in function 'protectedCall'
+        ./luaunit.lua:1508: in function 'execOneFunction'
+        ./luaunit.lua:1596: in function 'runSuiteByInstances'
+        ./luaunit.lua:1660: in function 'runSuiteByNames'
+        ./luaunit.lua:1736: in function 'runSuite'
+        example_with_luaunit.lua:140: in main chunk
+        [C]: in ?>>
+
+        Other example:
+    <<stack traceback:
+        ./luaunit.lua:545: in function 'assertEquals'
+        example_with_luaunit.lua:58: in function 'TestToto.test7'
+        ./luaunit.lua:1517: in function <./luaunit.lua:1517>
+        [C]: in function 'xpcall'
+        ./luaunit.lua:1517: in function 'protectedCall'
+        ./luaunit.lua:1578: in function 'execOneFunction'
+        ./luaunit.lua:1677: in function 'runSuiteByInstances'
+        ./luaunit.lua:1730: in function 'runSuiteByNames'
+        ./luaunit.lua:1806: in function 'runSuite'
+        example_with_luaunit.lua:140: in main chunk
+        [C]: in ?>>
+
+    <<stack traceback:
+        luaunit2/example_with_luaunit.lua:124: in function 'test1_withFailure'
+        luaunit2/luaunit.lua:1532: in function <luaunit2/luaunit.lua:1532>
+        [C]: in function 'xpcall'
+        luaunit2/luaunit.lua:1532: in function 'protectedCall'
+        luaunit2/luaunit.lua:1591: in function 'execOneFunction'
+        luaunit2/luaunit.lua:1679: in function 'runSuiteByInstances'
+        luaunit2/luaunit.lua:1743: in function 'runSuiteByNames'
+        luaunit2/luaunit.lua:1819: in function 'runSuite'
+        luaunit2/example_with_luaunit.lua:140: in main chunk
+        [C]: in ?>>
+
+
+    -- first line is "stack traceback": KEEP
+    -- next line may be luaunit line: REMOVE
+    -- next lines are call in the program under testOk: REMOVE
+    -- next lines are calls from luaunit to call the program under test: KEEP
+
+    -- Strategy:
+    -- keep first line
+    -- remove lines that are part of luaunit
+    -- kepp lines until we hit a luaunit line
+    ]]
+
+    local function isLuaunitInternalLine( s )
+        -- return true if line of stack trace comes from inside luaunit
+        return s:find('[/\\]luaunit%.lua:%d+: ') ~= nil
+    end
+
+    -- print( '<<'..stackTrace..'>>' )
+
+    local t = strsplit( '\n', stackTrace )
+    -- print( prettystr(t) )
+
+    local idx = 2
+
+    -- remove lines that are still part of luaunit
+    while t[idx] and isLuaunitInternalLine( t[idx] ) do
+        -- print('Removing : '..t[idx] )
+        table.remove(t, idx)
+    end
+
+    -- keep lines until we hit luaunit again
+    while t[idx] and (not isLuaunitInternalLine(t[idx])) do
+        -- print('Keeping : '..t[idx] )
+        idx = idx + 1
+    end
+
+    -- remove remaining luaunit lines
+    while t[idx] do
+        -- print('Removing : '..t[idx] )
+        table.remove(t, idx)
+    end
+
+    -- print( prettystr(t) )
+    return table.concat( t, '\n')
+
+end
+M.private.stripLuaunitTrace = stripLuaunitTrace
+
+
+local function prettystr_sub(v, indentLevel, printTableRefs, recursionTable )
+    local type_v = type(v)
+    if "string" == type_v  then
+        -- use clever delimiters according to content:
+        -- enclose with single quotes if string contains ", but no '
+        if v:find('"', 1, true) and not v:find("'", 1, true) then
+            return "'" .. v .. "'"
+        end
+        -- use double quotes otherwise, escape embedded "
+        return '"' .. v:gsub('"', '\\"') .. '"'
+
+    elseif "table" == type_v then
+        --if v.__class__ then
+        --    return string.gsub( tostring(v), 'table', v.__class__ )
+        --end
+        return M.private._table_tostring(v, indentLevel, printTableRefs, recursionTable)
+
+    elseif "number" == type_v then
+        -- eliminate differences in formatting between various Lua versions
+        if v ~= v then
+            return "#NaN" -- "not a number"
+        end
+        if v == math.huge then
+            return "#Inf" -- "infinite"
+        end
+        if v == -math.huge then
+            return "-#Inf"
+        end
+        if _VERSION == "Lua 5.3" then
+            local i = math.tointeger(v)
+            if i then
+                return tostring(i)
+            end
+        end
+    end
+
+    return tostring(v)
+end
+
+local function prettystr( v )
+    --[[ Pretty string conversion, to display the full content of a variable of any type.
+
+    * string are enclosed with " by default, or with ' if string contains a "
+    * tables are expanded to show their full content, with indentation in case of nested tables
+    ]]--
+    local recursionTable = {}
+    local s = prettystr_sub(v, 1, M.PRINT_TABLE_REF_IN_ERROR_MSG, recursionTable)
+    if recursionTable.recursionDetected and not M.PRINT_TABLE_REF_IN_ERROR_MSG then
+        -- some table contain recursive references,
+        -- so we must recompute the value by including all table references
+        -- else the result looks like crap
+        recursionTable = {}
+        s = prettystr_sub(v, 1, true, recursionTable)
+    end
+    return s
+end
+M.prettystr = prettystr
+
+function M.adjust_err_msg_with_iter( err_msg, iter_msg )
+    --[[ Adjust the error message err_msg: trim the FAILURE_PREFIX or SUCCESS_PREFIX information if needed, 
+    add the iteration message if any and return the result.
+
+    err_msg:  string, error message captured with pcall
+    iter_msg: a string describing the current iteration ("iteration N") or nil
+              if there is no iteration in this test.
+
+    Returns: (new_err_msg, test_status)
+        new_err_msg: string, adjusted error message, or nil in case of success
+        test_status: M.NodeStatus.FAIL, SUCCESS or ERROR according to the information
+                     contained in the error message.
+    ]]
+    if iter_msg then
+        iter_msg = iter_msg..', '
+    else
+        iter_msg = ''
+    end
+
+    local RE_FILE_LINE = '.*:%d+: '
+
+    if (err_msg:find( M.SUCCESS_PREFIX ) == 1) or err_msg:match( '('..RE_FILE_LINE..')' .. M.SUCCESS_PREFIX .. ".*" ) then
+        -- test finished early with success()
+        return nil, M.NodeStatus.PASS
+    end
+
+    if (err_msg:find( M.FAILURE_PREFIX ) == 1) or (err_msg:match( '('..RE_FILE_LINE..')' .. M.FAILURE_PREFIX .. ".*" ) ~= nil) then
+        -- substitute prefix by iteration message
+        err_msg = err_msg:gsub(M.FAILURE_PREFIX, iter_msg, 1)
+        -- print("failure detected")
+        return err_msg, M.NodeStatus.FAIL
+    else
+        -- print("error detected")
+        -- regular error, not a failure
+        if iter_msg then
+            local match
+            -- "./test\\test_luaunit.lua:2241: some error msg
+            match = err_msg:match( '(.*:%d+: ).*' ) 
+            if match then
+                err_msg = err_msg:gsub( match, match .. iter_msg )
+            else
+                -- no file:line: infromation, just add the iteration info at the beginning of the line
+                err_msg = iter_msg .. err_msg
+            end
+        end
+        return err_msg, M.NodeStatus.ERROR
+    end
+end
+
+local function tryMismatchFormatting( table_a, table_b, doDeepAnalysis )
+    --[[
+    Prepares a nice error message when comparing tables, performing a deeper 
+    analysis.
+
+    Arguments:
+    * table_a, table_b: tables to be compared
+    * doDeepAnalysis:
+        M.DEFAULT_DEEP_ANALYSIS: (the default if not specified) perform deep analysis only for big lists and big dictionnaries
+        M.FORCE_DEEP_ANALYSIS  : always perform deep analysis
+        M.DISABLE_DEEP_ANALYSIS: never perform deep analysis
+
+    Returns: {success, result}
+    * success: false if deep analysis could not be performed 
+               in this case, just use standard assertion message
+    * result: if success is true, a multi-line string with deep analysis of the two lists
+    ]]
+
+    -- check if table_a & table_b are suitable for deep analysis
+    if type(table_a) ~= 'table' or type(table_b) ~= 'table' then
+        return false
+    end
+
+    if doDeepAnalysis == M.DISABLE_DEEP_ANALYSIS then
+        return false
+    end
+
+    local len_a, len_b, isPureList = #table_a, #table_b, true
+
+    for k1, v1 in pairs(table_a) do
+        if type(k1) ~= 'number' or k1 > len_a then
+            -- this table a mapping
+            isPureList = false
+            break
+        end
+    end
+
+    if isPureList then
+        for k2, v2 in pairs(table_b) do
+            if type(k2) ~= 'number' or k2 > len_b then
+                -- this table a mapping
+                isPureList = false
+                break
+            end
+        end
+    end
+
+    if isPureList and math.min(len_a, len_b) < M.LIST_DIFF_ANALYSIS_THRESHOLD then
+        if not (doDeepAnalysis == M.FORCE_DEEP_ANALYSIS) then
+            return false
+        end
+    end
+
+    if isPureList then
+        return M.private.mismatchFormattingPureList( table_a, table_b )
+    else
+        -- only work on mapping for the moment
+        -- return M.private.mismatchFormattingMapping( table_a, table_b, doDeepAnalysis )
+        return false
+    end
+end
+M.private.tryMismatchFormatting = tryMismatchFormatting
+
+local function getTaTbDescr()
+    if not M.ORDER_ACTUAL_EXPECTED then
+        return 'expected', 'actual'
+    end
+    return 'actual', 'expected'
+end
+
+local function extendWithStrFmt( res, ... )
+    table.insert( res, string.format( ... ) )
+end
+
+local function mismatchFormattingMapping( table_a, table_b, doDeepAnalysis )
+    --[[
+    Prepares a nice error message when comparing tables which are not pure lists, performing a deeper 
+    analysis.
+
+    Returns: {success, result}
+    * success: false if deep analysis could not be performed 
+               in this case, just use standard assertion message
+    * result: if success is true, a multi-line string with deep analysis of the two lists
+    ]]
+
+    -- disable for the moment
+    --[[
+    local result = {}
+    local descrTa, descrTb = getTaTbDescr()
+
+    local keysCommon = {}
+    local keysOnlyTa = {}
+    local keysOnlyTb = {}
+    local keysDiffTaTb = {}
+
+    local k, v
+
+    for k,v in pairs( table_a ) do
+        if is_equal( v, table_b[k] ) then
+            table.insert( keysCommon, k )
+        else 
+            if table_b[k] == nil then
+                table.insert( keysOnlyTa, k )
+            else
+                table.insert( keysDiffTaTb, k )
+            end
+        end
+    end
+
+    for k,v in pairs( table_b ) do
+        if not is_equal( v, table_a[k] ) and table_a[k] == nil then
+            table.insert( keysOnlyTb, k )
+        end
+    end
+
+    local len_a = #keysCommon + #keysDiffTaTb + #keysOnlyTa
+    local len_b = #keysCommon + #keysDiffTaTb + #keysOnlyTb
+    local limited_display = (len_a < 5 or len_b < 5)
+
+    if math.min(len_a, len_b) < M.TABLE_DIFF_ANALYSIS_THRESHOLD then
+        return false
+    end
+
+    if not limited_display then
+        if len_a == len_b then
+            extendWithStrFmt( result, 'Table A (%s) and B (%s) both have %d items', descrTa, descrTb, len_a )
+        else
+            extendWithStrFmt( result, 'Table A (%s) has %d items and table B (%s) has %d items', descrTa, len_a, descrTb, len_b )
+            end
+
+        if #keysCommon == 0 and #keysDiffTaTb == 0 then
+            table.insert( result, 'Table A and B have no keys in common, they are totally different')
+        else
+            local s_other = 'other '
+            if #keysCommon then
+                extendWithStrFmt( result, 'Table A and B have %d identical items', #keysCommon )
+            else
+                table.insert( result, 'Table A and B have no identical items' )
+                s_other = ''
+            end
+
+            if #keysDiffTaTb ~= 0 then
+                result[#result] = string.format( '%s and %d items differing present in both tables', result[#result], #keysDiffTaTb)
+            else
+                result[#result] = string.format( '%s and no %sitems differing present in both tables', result[#result], s_other, #keysDiffTaTb)
+            end
+        end
+
+        extendWithStrFmt( result, 'Table A has %d keys not present in table B and table B has %d keys not present in table A', #keysOnlyTa, #keysOnlyTb ) 
+    end
+
+    local function keytostring(k)
+        if "string" == type(k) and k:match("^[_%a][_%w]*$") then
+            return k
+        end
+        return prettystr(k)
+    end
+
+    if #keysDiffTaTb ~= 0 then
+        table.insert( result, 'Items differing in A and B:')
+        for k,v in sortedPairs( keysDiffTaTb ) do
+            extendWithStrFmt( result, '  - A[%s]: %s', keytostring(v), prettystr(table_a[v]) )
+            extendWithStrFmt( result, '  + B[%s]: %s', keytostring(v), prettystr(table_b[v]) )
+        end
+    end    
+
+    if #keysOnlyTa ~= 0 then
+        table.insert( result, 'Items only in table A:' )
+        for k,v in sortedPairs( keysOnlyTa ) do
+            extendWithStrFmt( result, '  - A[%s]: %s', keytostring(v), prettystr(table_a[v]) )
+        end
+    end
+
+    if #keysOnlyTb ~= 0 then
+        table.insert( result, 'Items only in table B:' )
+        for k,v in sortedPairs( keysOnlyTb ) do
+            extendWithStrFmt( result, '  + B[%s]: %s', keytostring(v), prettystr(table_b[v]) )
+        end
+    end
+
+    if #keysCommon ~= 0 then
+        table.insert( result, 'Items common to A and B:')
+        for k,v in sortedPairs( keysCommon ) do
+            extendWithStrFmt( result, '  = A and B [%s]: %s', keytostring(v), prettystr(table_a[v]) )
+        end
+    end    
+
+    return true, table.concat( result, '\n')
+    ]]
+end
+M.private.mismatchFormattingMapping = mismatchFormattingMapping
+
+local function mismatchFormattingPureList( table_a, table_b )
+    --[[
+    Prepares a nice error message when comparing tables which are lists, performing a deeper 
+    analysis.
+
+    Returns: {success, result}
+    * success: false if deep analysis could not be performed 
+               in this case, just use standard assertion message
+    * result: if success is true, a multi-line string with deep analysis of the two lists
+    ]]
+    local result, descrTa, descrTb = {}, getTaTbDescr()
+
+    local len_a, len_b, refa, refb = #table_a, #table_b, '', ''
+    if M.PRINT_TABLE_REF_IN_ERROR_MSG then
+        refa, refb = string.format( '<%s> ', tostring(table_a)), string.format('<%s> ', tostring(table_b) )
+    end
+    local longest, shortest = math.max(len_a, len_b), math.min(len_a, len_b)
+    local deltalv  = longest - shortest
+
+    local commonUntil = shortest
+    for i = 1, shortest do
+        if not is_equal(table_a[i], table_b[i]) then
+            commonUntil = i - 1
+            break
+        end
+    end
+
+    local commonBackTo = shortest - 1
+    for i = 0, shortest - 1 do
+        if not is_equal(table_a[len_a-i], table_b[len_b-i]) then
+            commonBackTo = i - 1
+            break
+        end
+    end
+
+
+    table.insert( result, 'List difference analysis:' )    
+    if len_a == len_b then
+        -- TODO: handle expected/actual naming
+        extendWithStrFmt( result, '* lists %sA (%s) and %sB (%s) have the same size', refa, descrTa, refb, descrTb )
+    else 
+        extendWithStrFmt( result, '* list sizes differ: list %sA (%s) has %d items, list %sB (%s) has %d items', refa, descrTa, len_a, refb, descrTb, len_b )
+    end
+
+    extendWithStrFmt( result, '* lists A and B start differing at index %d', commonUntil+1 ) 
+    if commonBackTo >= 0 then
+        if deltalv > 0 then
+            extendWithStrFmt( result, '* lists A and B are equal again from index %d for A, %d for B', len_a-commonBackTo, len_b-commonBackTo )
+        else
+            extendWithStrFmt( result, '* lists A and B are equal again from index %d', len_a-commonBackTo )
+        end
+    end
+
+    local function insertABValue(ai, bi)
+        bi = bi or ai
+        if is_equal( table_a[ai], table_b[bi]) then
+            return extendWithStrFmt( result, '  = A[%d], B[%d]: %s', ai, bi, prettystr(table_a[ai]) )
+        else
+            extendWithStrFmt( result, '  - A[%d]: %s', ai, prettystr(table_a[ai]))
+            extendWithStrFmt( result, '  + B[%d]: %s', bi, prettystr(table_b[bi]))
+        end
+    end
+
+    -- common parts to list A & B, at the beginning
+    if commonUntil > 0 then
+        table.insert( result, '* Common parts:' )
+        for i = 1, commonUntil do
+            insertABValue( i )
+        end
+    end
+
+    -- diffing parts to list A & B
+    if commonUntil < shortest - commonBackTo - 1 then
+        table.insert( result, '* Differing parts:' )
+        for i = commonUntil + 1, shortest - commonBackTo - 1 do
+            insertABValue( i )
+        end
+    end
+
+    -- display indexes of one list, with no match on other list
+    if shortest - commonBackTo <= longest - commonBackTo - 1 then
+        table.insert( result, '* Present only in one list:' )
+        for i = shortest - commonBackTo, longest - commonBackTo - 1 do
+            if len_a > len_b then
+                extendWithStrFmt( result, '  - A[%d]: %s', i, prettystr(table_a[i]) )
+                -- table.insert( result, '+ (no matching B index)')
+            else
+                -- table.insert( result, '- no matching A index')
+                extendWithStrFmt( result, '  + B[%d]: %s', i, prettystr(table_b[i]) )
+            end
+        end
+    end
+
+    -- common parts to list A & B, at the end
+    if commonBackTo >= 0 then
+        table.insert( result, '* Common parts at the end of the lists' )
+        for i = longest - commonBackTo, longest do
+            if len_a > len_b then
+                insertABValue( i, i-deltalv )
+            else
+                insertABValue( i-deltalv, i )
+            end
+        end
+    end
+
+    return true, table.concat( result, '\n')
+end
+M.private.mismatchFormattingPureList = mismatchFormattingPureList
+
+local function prettystrPairs(value1, value2, suffix_a, suffix_b)
+    --[[
+    This function helps with the recurring task of constructing the "expected
+    vs. actual" error messages. It takes two arbitrary values and formats
+    corresponding strings with prettystr().
+
+    To keep the (possibly complex) output more readable in case the resulting
+    strings contain line breaks, they get automatically prefixed with additional
+    newlines. Both suffixes are optional (default to empty strings), and get
+    appended to the "value1" string. "suffix_a" is used if line breaks were
+    encountered, "suffix_b" otherwise.
+
+    Returns the two formatted strings (including padding/newlines).
+    ]]
+    local str1, str2 = prettystr(value1), prettystr(value2)
+    if hasNewLine(str1) or hasNewLine(str2) then
+        -- line break(s) detected, add padding
+        return "\n" .. str1 .. (suffix_a or ""), "\n" .. str2
+    end
+    return str1 .. (suffix_b or ""), str2
+end
+M.private.prettystrPairs = prettystrPairs
+
+local function _table_raw_tostring( t )
+    -- return the default tostring() for tables, with the table ID, even if the table has a metatable
+    -- with the __tostring converter
+    local mt = getmetatable( t )
+    if mt then setmetatable( t, nil ) end
+    local ref = tostring(t)
+    if mt then setmetatable( t, mt ) end
+    return ref
+end
+M.private._table_raw_tostring = _table_raw_tostring
+
+local TABLE_TOSTRING_SEP = ", "
+local TABLE_TOSTRING_SEP_LEN = string.len(TABLE_TOSTRING_SEP)
+
+local function _table_tostring( tbl, indentLevel, printTableRefs, recursionTable )
+    printTableRefs = printTableRefs or M.PRINT_TABLE_REF_IN_ERROR_MSG
+    recursionTable = recursionTable or {}
+    recursionTable[tbl] = true
+
+    local result, dispOnMultLines = {}, false
+
+    -- like prettystr but do not enclose with "" if the string is just alphanumerical
+    -- this is better for displaying table keys who are often simple strings
+    local function keytostring(k)
+        if "string" == type(k) and k:match("^[_%a][_%w]*$") then
+            return k
+        end
+        return prettystr_sub(k, indentLevel+1, printTableRefs, recursionTable)
+    end
+
+    local mt = getmetatable( tbl )
+
+    if mt and mt.__tostring then
+        -- if table has a __tostring() function in its metatable, use it to display the table
+        -- else, compute a regular table
+        result = strsplit( '\n', tostring(tbl) )
+        return M.private._table_tostring_format_multiline_string( result, indentLevel )
+
+    else
+        -- no metatable, compute the table representation
+
+        local entry, count, seq_index = nil, 0, 1
+        for k, v in sortedPairs( tbl ) do
+
+            -- key part
+            if k == seq_index then
+                -- for the sequential part of tables, we'll skip the "<key>=" output
+                entry = ''
+                seq_index = seq_index + 1
+            elseif recursionTable[k] then
+                -- recursion in the key detected
+                recursionTable.recursionDetected = true
+                entry = "<".._table_raw_tostring(k)..">="
+            else
+                entry = keytostring(k) .. "="
+            end
+
+            -- value part 
+            if recursionTable[v] then
+                -- recursion in the value detected!
+                recursionTable.recursionDetected = true
+                entry = entry .. "<".._table_raw_tostring(v)..">"
+            else
+                entry = entry ..
+                    prettystr_sub( v, indentLevel+1, printTableRefs, recursionTable )
+            end
+            count = count + 1
+            result[count] = entry
+        end
+        return M.private._table_tostring_format_result( tbl, result, indentLevel, printTableRefs )
+    end
+
+end
+M.private._table_tostring = _table_tostring -- prettystr_sub() needs it
+
+local function _table_tostring_format_multiline_string( tbl_str, indentLevel )
+    local indentString = '\n'..string.rep("    ", indentLevel - 1)
+    return table.concat( tbl_str, indentString )
+
+end
+M.private._table_tostring_format_multiline_string = _table_tostring_format_multiline_string
+
+
+local function _table_tostring_format_result( tbl, result, indentLevel, printTableRefs )
+    -- final function called in _table_to_string() to format the resulting list of 
+    -- string describing the table.
+
+    local dispOnMultLines = false
+
+    -- set dispOnMultLines to true if the maximum LINE_LENGTH would be exceeded with the values
+    local totalLength = 0
+    for k, v in ipairs( result ) do
+        totalLength = totalLength + string.len( v )
+        if totalLength >= M.LINE_LENGTH then
+            dispOnMultLines = true
+            break
+        end
+    end
+
+    -- set dispOnMultLines to true if the max LINE_LENGTH would be exceeded
+    -- with the values and the separators.
+    if not dispOnMultLines then
+        -- adjust with length of separator(s):
+        -- two items need 1 sep, three items two seps, ... plus len of '{}'
+        if #result > 0 then
+            totalLength = totalLength + TABLE_TOSTRING_SEP_LEN * (#result - 1)
+        end
+        dispOnMultLines = (totalLength + 2 >= M.LINE_LENGTH)
+    end
+
+    -- now reformat the result table (currently holding element strings)
+    if dispOnMultLines then
+        local indentString = string.rep("    ", indentLevel - 1)
+        result = {  
+                    "{\n    ", 
+                    indentString,
+                    table.concat(result, ",\n    " .. indentString), 
+                    "\n",
+                    indentString, 
+                    "}"
+                }
+    else
+        result = {"{", table.concat(result, TABLE_TOSTRING_SEP), "}"}
+    end
+    if printTableRefs then
+        table.insert(result, 1, "<".._table_raw_tostring(tbl).."> ") -- prepend table ref
+    end
+    return table.concat(result)
+end
+M.private._table_tostring_format_result = _table_tostring_format_result -- prettystr_sub() needs it
+
+local function _table_contains(t, element)
+    if type(t) == "table" then
+        local type_e = type(element)
+        for _, value in pairs(t) do
+            if type(value) == type_e then
+                if value == element then
+                    return true
+                end
+                if type_e == 'table' then
+                    -- if we wanted recursive items content comparison, we could use
+                    -- _is_table_items_equals(v, expected) but one level of just comparing
+                    -- items is sufficient
+                    if M.private._is_table_equals( value, element ) then
+                        return true
+                    end
+                end
+            end
+        end
+    end
+    return false
+end
+
+local function _is_table_items_equals(actual, expected )
+    local type_a, type_e = type(actual), type(expected)
+
+    if (type_a == 'table') and (type_e == 'table') then
+        for k, v in pairs(actual) do
+            if not _table_contains(expected, v) then
+                return false
+            end
+        end
+        for k, v in pairs(expected) do
+            if not _table_contains(actual, v) then
+                return false
+            end
+        end
+        return true
+
+    elseif type_a ~= type_e then
+        return false
+
+    elseif actual ~= expected then
+        return false
+    end
+
+    return true
+end
+
+--[[
+This is a specialized metatable to help with the bookkeeping of recursions
+in _is_table_equals(). It provides an __index table that implements utility
+functions for easier management of the table. The "cached" method queries
+the state of a specific (actual,expected) pair; and the "store" method sets
+this state to the given value. The state of pairs not "seen" / visited is
+assumed to be `nil`.
+]]
+local _recursion_cache_MT = {
+    __index = {
+        -- Return the cached value for an (actual,expected) pair (or `nil`)
+        cached = function(t, actual, expected)
+            local subtable = t[actual] or {}
+            return subtable[expected]
+        end,
+
+        -- Store cached value for a specific (actual,expected) pair.
+        -- Returns the value, so it's easy to use for a "tailcall" (return ...).
+        store = function(t, actual, expected, value, asymmetric)
+            local subtable = t[actual]
+            if not subtable then
+                subtable = {}
+                t[actual] = subtable
+            end
+            subtable[expected] = value
+
+            -- Unless explicitly marked "asymmetric": Consider the recursion
+            -- on (expected,actual) to be equivalent to (actual,expected) by
+            -- default, and thus cache the value for both.
+            if not asymmetric then
+                t:store(expected, actual, value, true)
+            end
+
+            return value
+        end
+    }
+}
+
+local function _is_table_equals(actual, expected, recursions)
+    local type_a, type_e = type(actual), type(expected)
+    recursions = recursions or setmetatable({}, _recursion_cache_MT)
+
+    if type_a ~= type_e then
+        return false -- different types won't match
+    end
+
+    if (type_a == 'table') --[[ and (type_e == 'table') ]] then
+        if actual == expected then
+            -- Both reference the same table, so they are actually identical
+            return recursions:store(actual, expected, true)
+        end
+
+        -- If we've tested this (actual,expected) pair before: return cached value
+        local previous = recursions:cached(actual, expected)
+        if previous ~= nil then
+            return previous
+        end
+
+        -- Mark this (actual,expected) pair, so we won't recurse it again. For
+        -- now, assume a "false" result, which we might adjust later if needed.
+        recursions:store(actual, expected, false)
+
+        -- Tables must have identical element count, or they can't match.
+        if (#actual ~= #expected) then
+            return false
+        end
+
+        local actualKeysMatched, actualTableKeys = {}, {}
+
+        for k, v in pairs(actual) do
+            if M.TABLE_EQUALS_KEYBYCONTENT and type(k) == "table" then
+                -- If the keys are tables, things get a bit tricky here as we
+                -- can have _is_table_equals(t[k1], t[k2]) despite k1 ~= k2. So
+                -- we first collect table keys from "actual", and then later try
+                -- to match each table key from "expected" to actualTableKeys.
+                table.insert(actualTableKeys, k)
+            else
+                if not _is_table_equals(v, expected[k], recursions) then
+                    return false -- Mismatch on value, tables can't be equal
+                end
+                actualKeysMatched[k] = true -- Keep track of matched keys
+            end
+        end
+
+        for k, v in pairs(expected) do
+            if M.TABLE_EQUALS_KEYBYCONTENT and type(k) == "table" then
+                local found = false
+                -- Note: DON'T use ipairs() here, table may be non-sequential!
+                for i, candidate in pairs(actualTableKeys) do
+                    if _is_table_equals(candidate, k, recursions) then
+                        if _is_table_equals(actual[candidate], v, recursions) then
+                            found = true
+                            -- Remove the candidate we matched against from the list
+                            -- of table keys, so each key in actual can only match
+                            -- one key in expected.
+                            actualTableKeys[i] = nil
+                            break
+                        end
+                        -- keys match but values don't, keep searching
+                    end
+                end
+                if not found then
+                    return false -- no matching (key,value) pair
+                end
+            else
+                if not actualKeysMatched[k] then
+                    -- Found a key that we did not see in "actual" -> mismatch
+                    return false
+                end
+                -- Otherwise actual[k] was already matched against v = expected[k].
+            end
+        end
+
+        if next(actualTableKeys) then
+            -- If there is any key left in actualTableKeys, then that is
+            -- a table-type key in actual with no matching counterpart
+            -- (in expected), and so the tables aren't equal.
+            return false
+        end
+
+        -- The tables are actually considered equal, update cache and return result
+        return recursions:store(actual, expected, true)
+
+    elseif actual ~= expected then
+        return false
+    end
+
+    return true
+end
+M.private._is_table_equals = _is_table_equals
+is_equal = _is_table_equals
+
+local function failure(main_msg, extra_msg_or_nil, level)
+    -- raise an error indicating a test failure
+    -- for error() compatibility we adjust "level" here (by +1), to report the
+    -- calling context
+    local msg
+    if type(extra_msg_or_nil) == 'string' and extra_msg_or_nil:len() > 0 then
+        msg = extra_msg_or_nil .. '\n' .. main_msg
+    else
+        msg = main_msg
+    end
+    error(M.FAILURE_PREFIX .. msg, (level or 1) + 1)
+end
+
+local function fail_fmt(level, extra_msg_or_nil, ...)
+     -- failure with printf-style formatted message and given error level
+    failure(string.format(...), extra_msg_or_nil, (level or 1) + 1)
+end
+M.private.fail_fmt = fail_fmt
+
+local function error_fmt(level, ...)
+     -- printf-style error()
+    error(string.format(...), (level or 1) + 1)
+end
+
+----------------------------------------------------------------
+--
+--                     assertions
+--
+----------------------------------------------------------------
+
+local function errorMsgEquality(actual, expected, doDeepAnalysis)
+
+    if not M.ORDER_ACTUAL_EXPECTED then
+        expected, actual = actual, expected
+    end
+    if type(expected) == 'string' or type(expected) == 'table' then
+        local strExpected, strActual = prettystrPairs(expected, actual)
+        local result = string.format("expected: %s\nactual: %s", strExpected, strActual)
+
+        -- extend with mismatch analysis if possible:
+        local success, mismatchResult
+        success, mismatchResult = tryMismatchFormatting( actual, expected, doDeepAnalysis )
+        if success then 
+            result = table.concat( { result, mismatchResult }, '\n' )
+        end
+        return result
+    end
+    return string.format("expected: %s, actual: %s",
+                         prettystr(expected), prettystr(actual))
+end
+
+function M.assertError(f, ...)
+    -- assert that calling f with the arguments will raise an error
+    -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
+    if pcall( f, ... ) then
+        failure( "Expected an error when calling function but no error generated", nil, 2 )
+    end
+end
+
+function M.fail( msg )
+    -- stops a test due to a failure
+    failure( msg, nil, 2 )
+end
+
+function M.failIf( cond, msg )
+    -- Fails a test with "msg" if condition is true
+    if cond then
+        failure( msg, nil, 2 )
+    end
+end
+
+function M.success()
+    -- stops a test with a success
+    error(M.SUCCESS_PREFIX, 2)
+end
+
+function M.successIf( cond )
+    -- stops a test with a success if condition is met
+    if cond then
+        error(M.SUCCESS_PREFIX, 2)
+    end
+end
+
+
+------------------------------------------------------------------
+--                  Equality assertions
+------------------------------------------------------------------
+
+function M.assertEquals(actual, expected, extra_msg_or_nil, doDeepAnalysis)
+    if type(actual) == 'table' and type(expected) == 'table' then
+        if not _is_table_equals(actual, expected) then
+            failure( errorMsgEquality(actual, expected, doDeepAnalysis), extra_msg_or_nil, 2 )
+        end
+    elseif type(actual) ~= type(expected) then
+        failure( errorMsgEquality(actual, expected), extra_msg_or_nil, 2 )
+    elseif actual ~= expected then
+        failure( errorMsgEquality(actual, expected), extra_msg_or_nil, 2 )
+    end
+end
+
+function M.almostEquals( actual, expected, margin )
+    if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
+        error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',
+            prettystr(actual), prettystr(expected), prettystr(margin))
+    end
+    if margin < 0 then
+        error('almostEquals: margin must not be negative, current value is ' .. margin, 3)
+    end
+    return math.abs(expected - actual) <= margin
+end
+
+function M.assertAlmostEquals( actual, expected, margin, extra_msg_or_nil )
+    -- check that two floats are close by margin
+    margin = margin or M.EPS
+    if not M.almostEquals(actual, expected, margin) then
+        if not M.ORDER_ACTUAL_EXPECTED then
+            expected, actual = actual, expected
+        end
+        local delta = math.abs(actual - expected) 
+        fail_fmt(2, extra_msg_or_nil, 'Values are not almost equal\n' ..
+                    'Actual: %s, expected: %s, delta %s above margin of %s',
+                    actual, expected, delta, margin)
+    end
+end
+
+function M.assertNotEquals(actual, expected, extra_msg_or_nil)
+    if type(actual) ~= type(expected) then
+        return
+    end
+
+    if type(actual) == 'table' and type(expected) == 'table' then
+        if not _is_table_equals(actual, expected) then
+            return
+        end
+    elseif actual ~= expected then
+        return
+    end
+    fail_fmt(2, extra_msg_or_nil, 'Received the not expected value: %s', prettystr(actual))
+end
+
+function M.assertNotAlmostEquals( actual, expected, margin, extra_msg_or_nil )
+    -- check that two floats are not close by margin
+    margin = margin or M.EPS
+    if M.almostEquals(actual, expected, margin) then
+        if not M.ORDER_ACTUAL_EXPECTED then
+            expected, actual = actual, expected
+        end
+        local delta = math.abs(actual - expected)
+        fail_fmt(2, extra_msg_or_nil, 'Values are almost equal\nActual: %s, expected: %s' ..
+                    ', delta %s below margin of %s',
+                    actual, expected, delta, margin)
+    end
+end
+
+function M.assertItemsEquals(actual, expected, extra_msg_or_nil)
+    -- checks that the items of table expected
+    -- are contained in table actual. Warning, this function
+    -- is at least O(n^2)
+    if not _is_table_items_equals(actual, expected ) then
+        expected, actual = prettystrPairs(expected, actual)
+        fail_fmt(2, extra_msg_or_nil, 'Content of the tables are not identical:\nExpected: %s\nActual: %s',
+                 expected, actual)
+    end
+end
+
+------------------------------------------------------------------
+--                  String assertion
+------------------------------------------------------------------
+
+function M.assertStrContains( str, sub, isPattern, extra_msg_or_nil )
+    -- this relies on lua string.find function
+    -- a string always contains the empty string
+    if not string.find(str, sub, 1, not isPattern) then
+        sub, str = prettystrPairs(sub, str, '\n')
+        fail_fmt(2, extra_msg_or_nil, 'Could not find %s %s in string %s',
+                 isPattern and 'pattern' or 'substring', sub, str)
+    end
+end
+
+function M.assertStrIContains( str, sub, extra_msg_or_nil )
+    -- this relies on lua string.find function
+    -- a string always contains the empty string
+    if not string.find(str:lower(), sub:lower(), 1, true) then
+        sub, str = prettystrPairs(sub, str, '\n')
+        fail_fmt(2, extra_msg_or_nil, 'Could not find (case insensitively) substring %s in string %s',
+                 sub, str)
+    end
+end
+
+function M.assertNotStrContains( str, sub, isPattern, extra_msg_or_nil )
+    -- this relies on lua string.find function
+    -- a string always contains the empty string
+    if string.find(str, sub, 1, not isPattern) then
+        sub, str = prettystrPairs(sub, str, '\n')
+        fail_fmt(2, extra_msg_or_nil, 'Found the not expected %s %s in string %s',
+                 isPattern and 'pattern' or 'substring', sub, str)
+    end
+end
+
+function M.assertNotStrIContains( str, sub, extra_msg_or_nil )
+    -- this relies on lua string.find function
+    -- a string always contains the empty string
+    if string.find(str:lower(), sub:lower(), 1, true) then
+        sub, str = prettystrPairs(sub, str, '\n')
+        fail_fmt(2, extra_msg_or_nil, 'Found (case insensitively) the not expected substring %s in string %s',
+                 sub, str)
+    end
+end
+
+function M.assertStrMatches( str, pattern, start, final, extra_msg_or_nil )
+    -- Verify a full match for the string
+    if not strMatch( str, pattern, start, final ) then
+        pattern, str = prettystrPairs(pattern, str, '\n')
+        fail_fmt(2, extra_msg_or_nil, 'Could not match pattern %s with string %s',
+                 pattern, str)
+    end
+end
+
+function M.assertErrorMsgEquals( expectedMsg, func, ... )
+    -- assert that calling f with the arguments will raise an error
+    -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
+    local no_error, error_msg = pcall( func, ... )
+    if no_error then
+        failure( 'No error generated when calling function but expected error: '..M.prettystr(expectedMsg), nil, 2 )
+    end
+    if type(expectedMsg) == "string" and type(error_msg) ~= "string" then
+        -- table are converted to string automatically
+        error_msg = tostring(error_msg)
+    end
+    local differ = false
+    if error_msg ~= expectedMsg then
+        local tr = type(error_msg)
+        local te = type(expectedMsg)
+        if te == 'table' then
+            if tr ~= 'table' then
+                differ = true
+            else
+                 local ok = pcall(M.assertItemsEquals, error_msg, expectedMsg)
+                 if not ok then
+                     differ = true
+                 end
+            end
+        else
+           differ = true
+        end
+    end
+
+    if differ then
+        error_msg, expectedMsg = prettystrPairs(error_msg, expectedMsg)
+        fail_fmt(2, nil, 'Error message expected: %s\nError message received: %s\n',
+                 expectedMsg, error_msg)
+    end
+end
+
+function M.assertErrorMsgContains( partialMsg, func, ... )
+    -- assert that calling f with the arguments will raise an error
+    -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
+    local no_error, error_msg = pcall( func, ... )
+    if no_error then
+        failure( 'No error generated when calling function but expected error containing: '..prettystr(partialMsg), nil, 2 )
+    end
+    if type(error_msg) ~= "string" then
+        error_msg = tostring(error_msg)
+    end
+    if not string.find( error_msg, partialMsg, nil, true ) then
+        error_msg, partialMsg = prettystrPairs(error_msg, partialMsg)
+        fail_fmt(2, nil, 'Error message does not contain: %s\nError message received: %s\n',
+                 partialMsg, error_msg)
+    end
+end
+
+function M.assertErrorMsgMatches( expectedMsg, func, ... )
+    -- assert that calling f with the arguments will raise an error
+    -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
+    local no_error, error_msg = pcall( func, ... )
+    if no_error then
+        failure( 'No error generated when calling function but expected error matching: "'..expectedMsg..'"', nil, 2 )
+    end
+    if type(error_msg) ~= "string" then
+        error_msg = tostring(error_msg)
+    end
+    if not strMatch( error_msg, expectedMsg ) then
+        expectedMsg, error_msg = prettystrPairs(expectedMsg, error_msg)
+        fail_fmt(2, nil, 'Error message does not match pattern: %s\nError message received: %s\n',
+                 expectedMsg, error_msg)
+    end
+end
+
+------------------------------------------------------------------
+--              Type assertions
+------------------------------------------------------------------
+
+function M.assertEvalToTrue(value, extra_msg_or_nil)
+    if not value then
+        failure("expected: a value evaluating to true, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertEvalToFalse(value, extra_msg_or_nil)
+    if value then
+        failure("expected: false or nil, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertIsTrue(value, extra_msg_or_nil)
+    if value ~= true then
+        failure("expected: true, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertNotIsTrue(value, extra_msg_or_nil)
+    if value == true then
+        failure("expected: not true, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertIsFalse(value, extra_msg_or_nil)
+    if value ~= false then
+        failure("expected: false, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertNotIsFalse(value, extra_msg_or_nil)
+    if value == false then
+        failure("expected: not false, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertIsNil(value, extra_msg_or_nil)
+    if value ~= nil then
+        failure("expected: nil, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertNotIsNil(value, extra_msg_or_nil)
+    if value == nil then
+        failure("expected: not nil, actual: nil", extra_msg_or_nil, 2)
+    end
+end
+
+--[[
+Add type assertion functions to the module table M. Each of these functions
+takes a single parameter "value", and checks that its Lua type matches the
+expected string (derived from the function name):
+
+M.assertIsXxx(value) -> ensure that type(value) conforms to "xxx"
+]]
+for _, funcName in ipairs(
+    {'assertIsNumber', 'assertIsString', 'assertIsTable', 'assertIsBoolean',
+     'assertIsFunction', 'assertIsUserdata', 'assertIsThread'}
+) do
+    local typeExpected = funcName:match("^assertIs([A-Z]%a*)$")
+    -- Lua type() always returns lowercase, also make sure the match() succeeded
+    typeExpected = typeExpected and typeExpected:lower()
+                   or error("bad function name '"..funcName.."' for type assertion")
+
+    M[funcName] = function(value, extra_msg_or_nil)
+        if type(value) ~= typeExpected then
+            if type(value) == 'nil' then
+                fail_fmt(2, extra_msg_or_nil, 'expected: a %s value, actual: nil',
+                         typeExpected, type(value), prettystrPairs(value))
+            else
+                fail_fmt(2, extra_msg_or_nil, 'expected: a %s value, actual: type %s, value %s',
+                         typeExpected, type(value), prettystrPairs(value))
+            end
+        end
+    end
+end
+
+--[[
+Add shortcuts for verifying type of a variable, without failure (luaunit v2 compatibility)
+M.isXxx(value) -> returns true if type(value) conforms to "xxx"
+]]
+for _, typeExpected in ipairs(
+    {'Number', 'String', 'Table', 'Boolean',
+     'Function', 'Userdata', 'Thread', 'Nil' }
+) do
+    local typeExpectedLower = typeExpected:lower()
+    local isType = function(value)
+        return (type(value) == typeExpectedLower)
+    end
+    M['is'..typeExpected] = isType
+    M['is_'..typeExpectedLower] = isType
+end
+
+--[[
+Add non-type assertion functions to the module table M. Each of these functions
+takes a single parameter "value", and checks that its Lua type differs from the
+expected string (derived from the function name):
+
+M.assertNotIsXxx(value) -> ensure that type(value) is not "xxx"
+]]
+for _, funcName in ipairs(
+    {'assertNotIsNumber', 'assertNotIsString', 'assertNotIsTable', 'assertNotIsBoolean',
+     'assertNotIsFunction', 'assertNotIsUserdata', 'assertNotIsThread'}
+) do
+    local typeUnexpected = funcName:match("^assertNotIs([A-Z]%a*)$")
+    -- Lua type() always returns lowercase, also make sure the match() succeeded
+    typeUnexpected = typeUnexpected and typeUnexpected:lower()
+                   or error("bad function name '"..funcName.."' for type assertion")
+
+    M[funcName] = function(value, extra_msg_or_nil)
+        if type(value) == typeUnexpected then
+            fail_fmt(2, extra_msg_or_nil, 'expected: not a %s type, actual: value %s',
+                     typeUnexpected, prettystrPairs(value))
+        end
+    end
+end
+
+function M.assertIs(actual, expected, extra_msg_or_nil)
+    if actual ~= expected then
+        if not M.ORDER_ACTUAL_EXPECTED then
+            actual, expected = expected, actual
+        end
+        expected, actual = prettystrPairs(expected, actual, '\n', '')
+        fail_fmt(2, extra_msg_or_nil, 'expected and actual object should not be different\nExpected: %s\nReceived: %s',
+                 expected, actual)
+    end
+end
+
+function M.assertNotIs(actual, expected, extra_msg_or_nil)
+    if actual == expected then
+        if not M.ORDER_ACTUAL_EXPECTED then
+            expected = actual
+        end
+        fail_fmt(2, extra_msg_or_nil, 'expected and actual object should be different: %s',
+                 prettystrPairs(expected))
+    end
+end
+
+
+------------------------------------------------------------------
+--              Scientific assertions
+------------------------------------------------------------------
+
+
+function M.assertIsNaN(value, extra_msg_or_nil)
+    if type(value) ~= "number" or value == value then
+        failure("expected: NaN, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertNotIsNaN(value, extra_msg_or_nil)
+    if type(value) == "number" and value ~= value then
+        failure("expected: not NaN, actual: NaN", extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertIsInf(value, extra_msg_or_nil)
+    if type(value) ~= "number" or math.abs(value) ~= math.huge then
+        failure("expected: #Inf, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertIsPlusInf(value, extra_msg_or_nil)
+    if type(value) ~= "number" or value ~= math.huge then
+        failure("expected: #Inf, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertIsMinusInf(value, extra_msg_or_nil)
+    if type(value) ~= "number" or value ~= -math.huge then
+        failure("expected: -#Inf, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertNotIsPlusInf(value, extra_msg_or_nil)
+    if type(value) == "number" and value == math.huge then
+        failure("expected: not #Inf, actual: #Inf", extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertNotIsMinusInf(value, extra_msg_or_nil)
+    if type(value) == "number" and value == -math.huge then
+        failure("expected: not -#Inf, actual: -#Inf", extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertNotIsInf(value, extra_msg_or_nil)
+    if type(value) == "number" and math.abs(value) == math.huge then
+        failure("expected: not infinity, actual: " .. prettystr(value), extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertIsPlusZero(value, extra_msg_or_nil)
+    if type(value) ~= 'number' or value ~= 0 then
+        failure("expected: +0.0, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    else if (1/value == -math.huge) then
+            -- more precise error diagnosis
+            failure("expected: +0.0, actual: -0.0", extra_msg_or_nil, 2)
+        else if (1/value ~= math.huge) then
+                -- strange, case should have already been covered
+                failure("expected: +0.0, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+            end
+        end
+    end
+end
+
+function M.assertIsMinusZero(value, extra_msg_or_nil)
+    if type(value) ~= 'number' or value ~= 0 then
+        failure("expected: -0.0, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+    else if (1/value == math.huge) then
+            -- more precise error diagnosis
+            failure("expected: -0.0, actual: +0.0", extra_msg_or_nil, 2)
+        else if (1/value ~= -math.huge) then
+                -- strange, case should have already been covered
+                failure("expected: -0.0, actual: " ..prettystr(value), extra_msg_or_nil, 2)
+            end
+        end
+    end
+end
+
+function M.assertNotIsPlusZero(value, extra_msg_or_nil)
+    if type(value) == 'number' and (1/value == math.huge) then
+        failure("expected: not +0.0, actual: +0.0", extra_msg_or_nil, 2)
+    end
+end
+
+function M.assertNotIsMinusZero(value, extra_msg_or_nil)
+    if type(value) == 'number' and (1/value == -math.huge) then
+        failure("expected: not -0.0, actual: -0.0", extra_msg_or_nil, 2)
+    end
+end
+
+----------------------------------------------------------------
+--                     Compatibility layer
+----------------------------------------------------------------
+
+-- for compatibility with LuaUnit v2.x
+function M.wrapFunctions()
+    -- In LuaUnit version <= 2.1 , this function was necessary to include
+    -- a test function inside the global test suite. Nowadays, the functions
+    -- are simply run directly as part of the test discovery process.
+    -- so just do nothing !
+    io.stderr:write[[Use of WrapFunctions() is no longer needed.
+Just prefix your test function names with "test" or "Test" and they
+will be picked up and run by LuaUnit.
+]]
+end
+
+local list_of_funcs = {
+    -- { official function name , alias }
+
+    -- general assertions
+    { 'assertEquals'            , 'assert_equals' },
+    { 'assertItemsEquals'       , 'assert_items_equals' },
+    { 'assertNotEquals'         , 'assert_not_equals' },
+    { 'assertAlmostEquals'      , 'assert_almost_equals' },
+    { 'assertNotAlmostEquals'   , 'assert_not_almost_equals' },
+    { 'assertEvalToTrue'        , 'assert_eval_to_true' },
+    { 'assertEvalToFalse'       , 'assert_eval_to_false' },
+    { 'assertStrContains'       , 'assert_str_contains' },
+    { 'assertStrIContains'      , 'assert_str_icontains' },
+    { 'assertNotStrContains'    , 'assert_not_str_contains' },
+    { 'assertNotStrIContains'   , 'assert_not_str_icontains' },
+    { 'assertStrMatches'        , 'assert_str_matches' },
+    { 'assertError'             , 'assert_error' },
+    { 'assertErrorMsgEquals'    , 'assert_error_msg_equals' },
+    { 'assertErrorMsgContains'  , 'assert_error_msg_contains' },
+    { 'assertErrorMsgMatches'   , 'assert_error_msg_matches' },
+    { 'assertIs'                , 'assert_is' },
+    { 'assertNotIs'             , 'assert_not_is' },
+    { 'wrapFunctions'           , 'WrapFunctions' },
+    { 'wrapFunctions'           , 'wrap_functions' },
+
+    -- type assertions: assertIsXXX -> assert_is_xxx
+    { 'assertIsNumber'          , 'assert_is_number' },
+    { 'assertIsString'          , 'assert_is_string' },
+    { 'assertIsTable'           , 'assert_is_table' },
+    { 'assertIsBoolean'         , 'assert_is_boolean' },
+    { 'assertIsNil'             , 'assert_is_nil' },
+    { 'assertIsTrue'            , 'assert_is_true' },
+    { 'assertIsFalse'           , 'assert_is_false' },
+    { 'assertIsNaN'             , 'assert_is_nan' },
+    { 'assertIsInf'             , 'assert_is_inf' },
+    { 'assertIsPlusInf'         , 'assert_is_plus_inf' },
+    { 'assertIsMinusInf'        , 'assert_is_minus_inf' },
+    { 'assertIsPlusZero'        , 'assert_is_plus_zero' },
+    { 'assertIsMinusZero'       , 'assert_is_minus_zero' },
+    { 'assertIsFunction'        , 'assert_is_function' },
+    { 'assertIsThread'          , 'assert_is_thread' },
+    { 'assertIsUserdata'        , 'assert_is_userdata' },
+
+    -- type assertions: assertIsXXX -> assertXxx
+    { 'assertIsNumber'          , 'assertNumber' },
+    { 'assertIsString'          , 'assertString' },
+    { 'assertIsTable'           , 'assertTable' },
+    { 'assertIsBoolean'         , 'assertBoolean' },
+    { 'assertIsNil'             , 'assertNil' },
+    { 'assertIsTrue'            , 'assertTrue' },
+    { 'assertIsFalse'           , 'assertFalse' },
+    { 'assertIsNaN'             , 'assertNaN' },
+    { 'assertIsInf'             , 'assertInf' },
+    { 'assertIsPlusInf'         , 'assertPlusInf' },
+    { 'assertIsMinusInf'        , 'assertMinusInf' },
+    { 'assertIsPlusZero'        , 'assertPlusZero' },
+    { 'assertIsMinusZero'       , 'assertMinusZero'},
+    { 'assertIsFunction'        , 'assertFunction' },
+    { 'assertIsThread'          , 'assertThread' },
+    { 'assertIsUserdata'        , 'assertUserdata' },
+
+    -- type assertions: assertIsXXX -> assert_xxx (luaunit v2 compat)
+    { 'assertIsNumber'          , 'assert_number' },
+    { 'assertIsString'          , 'assert_string' },
+    { 'assertIsTable'           , 'assert_table' },
+    { 'assertIsBoolean'         , 'assert_boolean' },
+    { 'assertIsNil'             , 'assert_nil' },
+    { 'assertIsTrue'            , 'assert_true' },
+    { 'assertIsFalse'           , 'assert_false' },
+    { 'assertIsNaN'             , 'assert_nan' },
+    { 'assertIsInf'             , 'assert_inf' },
+    { 'assertIsPlusInf'         , 'assert_plus_inf' },
+    { 'assertIsMinusInf'        , 'assert_minus_inf' },
+    { 'assertIsPlusZero'        , 'assert_plus_zero' },
+    { 'assertIsMinusZero'       , 'assert_minus_zero' },
+    { 'assertIsFunction'        , 'assert_function' },
+    { 'assertIsThread'          , 'assert_thread' },
+    { 'assertIsUserdata'        , 'assert_userdata' },
+
+    -- type assertions: assertNotIsXXX -> assert_not_is_xxx
+    { 'assertNotIsNumber'       , 'assert_not_is_number' },
+    { 'assertNotIsString'       , 'assert_not_is_string' },
+    { 'assertNotIsTable'        , 'assert_not_is_table' },
+    { 'assertNotIsBoolean'      , 'assert_not_is_boolean' },
+    { 'assertNotIsNil'          , 'assert_not_is_nil' },
+    { 'assertNotIsTrue'         , 'assert_not_is_true' },
+    { 'assertNotIsFalse'        , 'assert_not_is_false' },
+    { 'assertNotIsNaN'          , 'assert_not_is_nan' },
+    { 'assertNotIsInf'          , 'assert_not_is_inf' },
+    { 'assertNotIsPlusInf'      , 'assert_not_plus_inf' },
+    { 'assertNotIsMinusInf'     , 'assert_not_minus_inf' },
+    { 'assertNotIsPlusZero'     , 'assert_not_plus_zero' },
+    { 'assertNotIsMinusZero'    , 'assert_not_minus_zero' },
+    { 'assertNotIsFunction'     , 'assert_not_is_function' },
+    { 'assertNotIsThread'       , 'assert_not_is_thread' },
+    { 'assertNotIsUserdata'     , 'assert_not_is_userdata' },
+
+    -- type assertions: assertNotIsXXX -> assertNotXxx (luaunit v2 compat)
+    { 'assertNotIsNumber'       , 'assertNotNumber' },
+    { 'assertNotIsString'       , 'assertNotString' },
+    { 'assertNotIsTable'        , 'assertNotTable' },
+    { 'assertNotIsBoolean'      , 'assertNotBoolean' },
+    { 'assertNotIsNil'          , 'assertNotNil' },
+    { 'assertNotIsTrue'         , 'assertNotTrue' },
+    { 'assertNotIsFalse'        , 'assertNotFalse' },
+    { 'assertNotIsNaN'          , 'assertNotNaN' },
+    { 'assertNotIsInf'          , 'assertNotInf' },
+    { 'assertNotIsPlusInf'      , 'assertNotPlusInf' },
+    { 'assertNotIsMinusInf'     , 'assertNotMinusInf' },
+    { 'assertNotIsPlusZero'     , 'assertNotPlusZero' },
+    { 'assertNotIsMinusZero'    , 'assertNotMinusZero' },
+    { 'assertNotIsFunction'     , 'assertNotFunction' },
+    { 'assertNotIsThread'       , 'assertNotThread' },
+    { 'assertNotIsUserdata'     , 'assertNotUserdata' },
+
+    -- type assertions: assertNotIsXXX -> assert_not_xxx
+    { 'assertNotIsNumber'       , 'assert_not_number' },
+    { 'assertNotIsString'       , 'assert_not_string' },
+    { 'assertNotIsTable'        , 'assert_not_table' },
+    { 'assertNotIsBoolean'      , 'assert_not_boolean' },
+    { 'assertNotIsNil'          , 'assert_not_nil' },
+    { 'assertNotIsTrue'         , 'assert_not_true' },
+    { 'assertNotIsFalse'        , 'assert_not_false' },
+    { 'assertNotIsNaN'          , 'assert_not_nan' },
+    { 'assertNotIsInf'          , 'assert_not_inf' },
+    { 'assertNotIsPlusInf'      , 'assert_not_plus_inf' },
+    { 'assertNotIsMinusInf'     , 'assert_not_minus_inf' },
+    { 'assertNotIsPlusZero'     , 'assert_not_plus_zero' },
+    { 'assertNotIsMinusZero'    , 'assert_not_minus_zero' },
+    { 'assertNotIsFunction'     , 'assert_not_function' },
+    { 'assertNotIsThread'       , 'assert_not_thread' },
+    { 'assertNotIsUserdata'     , 'assert_not_userdata' },
+
+    -- all assertions with Coroutine duplicate Thread assertions
+    { 'assertIsThread'          , 'assertIsCoroutine' },
+    { 'assertIsThread'          , 'assertCoroutine' },
+    { 'assertIsThread'          , 'assert_is_coroutine' },
+    { 'assertIsThread'          , 'assert_coroutine' },
+    { 'assertNotIsThread'       , 'assertNotIsCoroutine' },
+    { 'assertNotIsThread'       , 'assertNotCoroutine' },
+    { 'assertNotIsThread'       , 'assert_not_is_coroutine' },
+    { 'assertNotIsThread'       , 'assert_not_coroutine' },
+}
+
+-- Create all aliases in M
+for _,v in ipairs( list_of_funcs ) do
+    local funcname, alias = v[1], v[2]
+    M[alias] = M[funcname]
+
+    if EXPORT_ASSERT_TO_GLOBALS then
+        _G[funcname] = M[funcname]
+        _G[alias] = M[funcname]
+    end
+end
+
+----------------------------------------------------------------
+--
+--                     Outputters
+--
+----------------------------------------------------------------
+
+-- A common "base" class for outputters
+-- For concepts involved (class inheritance) see http://www.lua.org/pil/16.2.html
+
+local genericOutput = { __class__ = 'genericOutput' } -- class
+local genericOutput_MT = { __index = genericOutput } -- metatable
+M.genericOutput = genericOutput -- publish, so that custom classes may derive from it
+
+function genericOutput.new(runner, default_verbosity)
+    -- runner is the "parent" object controlling the output, usually a LuaUnit instance
+    local t = { runner = runner }
+    if runner then
+        t.result = runner.result
+        t.verbosity = runner.verbosity or default_verbosity
+        t.fname = runner.fname
+    else
+        t.verbosity = default_verbosity
+    end
+    return setmetatable( t, genericOutput_MT)
+end
+
+-- abstract ("empty") methods
+function genericOutput:startSuite() end
+function genericOutput:startClass(className) end
+function genericOutput:startTest(testName) end
+function genericOutput:addStatus(node) end
+function genericOutput:endTest(node) end
+function genericOutput:endClass() end
+function genericOutput:endSuite() end
+
+
+----------------------------------------------------------------
+--                     class TapOutput
+----------------------------------------------------------------
+
+local TapOutput = genericOutput.new() -- derived class
+local TapOutput_MT = { __index = TapOutput } -- metatable
+TapOutput.__class__ = 'TapOutput'
+
+    -- For a good reference for TAP format, check: http://testanything.org/tap-specification.html
+
+    function TapOutput.new(runner)
+        local t = genericOutput.new(runner, M.VERBOSITY_LOW)
+        return setmetatable( t, TapOutput_MT)
+    end
+    function TapOutput:startSuite()
+        print("1.."..self.result.testCount)
+        print('# Started on '..self.result.startDate)
+    end
+    function TapOutput:startClass(className)
+        if className ~= '[TestFunctions]' then
+            print('# Starting class: '..className)
+        end
+    end
+
+    function TapOutput:addStatus( node )
+        io.stdout:write("not ok ", self.result.currentTestNumber, "\t", node.testName, "\n")
+        if self.verbosity > M.VERBOSITY_LOW then
+           print( prefixString( '#   ', node.msg ) )
+        end
+        if self.verbosity > M.VERBOSITY_DEFAULT then
+           print( prefixString( '#   ', node.stackTrace ) )
+        end
+    end
+
+    function TapOutput:endTest( node )
+        if node:isPassed() then
+            io.stdout:write("ok     ", self.result.currentTestNumber, "\t", node.testName, "\n")
+        end
+    end
+
+    function TapOutput:endSuite()
+        print( '# '..M.LuaUnit.statusLine( self.result ) )
+        return self.result.notPassedCount
+    end
+
+
+-- class TapOutput end
+
+----------------------------------------------------------------
+--                     class JUnitOutput
+----------------------------------------------------------------
+
+-- See directory junitxml for more information about the junit format
+local JUnitOutput = genericOutput.new() -- derived class
+local JUnitOutput_MT = { __index = JUnitOutput } -- metatable
+JUnitOutput.__class__ = 'JUnitOutput'
+
+    function JUnitOutput.new(runner)
+        local t = genericOutput.new(runner, M.VERBOSITY_LOW)
+        t.testList = {}
+        return setmetatable( t, JUnitOutput_MT )
+    end
+
+    function JUnitOutput:startSuite()
+        -- open xml file early to deal with errors
+        if self.fname == nil then
+            error('With Junit, an output filename must be supplied with --name!')
+        end
+        if string.sub(self.fname,-4) ~= '.xml' then
+            self.fname = self.fname..'.xml'
+        end
+        self.fd = io.open(self.fname, "w")
+        if self.fd == nil then
+            error("Could not open file for writing: "..self.fname)
+        end
+
+        print('# XML output to '..self.fname)
+        print('# Started on '..self.result.startDate)
+    end
+    function JUnitOutput:startClass(className)
+        if className ~= '[TestFunctions]' then
+            print('# Starting class: '..className)
+        end
+    end
+    function JUnitOutput:startTest(testName)
+        print('# Starting test: '..testName)
+    end
+
+    function JUnitOutput:addStatus( node )
+        if node:isFailure() then
+            print( '#   Failure: ' .. prefixString( '#   ', node.msg ):sub(4, nil) )
+            -- print('# ' .. node.stackTrace)
+        elseif node:isError() then
+            print( '#   Error: ' .. prefixString( '#   '  , node.msg ):sub(4, nil) )
+            -- print('# ' .. node.stackTrace)
+        end
+    end
+
+    function JUnitOutput:endSuite()
+        print( '# '..M.LuaUnit.statusLine(self.result))
+
+        -- XML file writing
+        self.fd:write('<?xml version="1.0" encoding="UTF-8" ?>\n')
+        self.fd:write('<testsuites>\n')
+        self.fd:write(string.format(
+            '    <testsuite name="LuaUnit" id="00001" package="" hostname="localhost" tests="%d" timestamp="%s" time="%0.3f" errors="%d" failures="%d">\n',
+            self.result.runCount, self.result.startIsodate, self.result.duration, self.result.errorCount, self.result.failureCount ))
+        self.fd:write("        <properties>\n")
+        self.fd:write(string.format('            <property name="Lua Version" value="%s"/>\n', _VERSION ) )
+        self.fd:write(string.format('            <property name="LuaUnit Version" value="%s"/>\n', M.VERSION) )
+        -- XXX please include system name and version if possible
+        self.fd:write("        </properties>\n")
+
+        for i,node in ipairs(self.result.tests) do
+            self.fd:write(string.format('        <testcase classname="%s" name="%s" time="%0.3f">\n',
+                node.className, node.testName, node.duration ) )
+            if node:isNotPassed() then
+                self.fd:write(node:statusXML())
+            end
+            self.fd:write('        </testcase>\n')
+        end
+
+        -- Next two lines are needed to validate junit ANT xsd, but really not useful in general:
+        self.fd:write('    <system-out/>\n')
+        self.fd:write('    <system-err/>\n')
+
+        self.fd:write('    </testsuite>\n')
+        self.fd:write('</testsuites>\n')
+        self.fd:close()
+        return self.result.notPassedCount
+    end
+
+
+-- class TapOutput end
+
+----------------------------------------------------------------
+--                     class TextOutput
+----------------------------------------------------------------
+
+--[[
+
+-- Python Non verbose:
+
+For each test: . or F or E
+
+If some failed tests:
+    ==============
+    ERROR / FAILURE: TestName (testfile.testclass)
+    ---------
+    Stack trace
+
+
+then --------------
+then "Ran x tests in 0.000s"
+then OK or FAILED (failures=1, error=1)
+
+-- Python Verbose:
+testname (filename.classname) ... ok
+testname (filename.classname) ... FAIL
+testname (filename.classname) ... ERROR
+
+then --------------
+then "Ran x tests in 0.000s"
+then OK or FAILED (failures=1, error=1)
+
+-- Ruby:
+Started
+ .
+ Finished in 0.002695 seconds.
+
+ 1 tests, 2 assertions, 0 failures, 0 errors
+
+-- Ruby:
+>> ruby tc_simple_number2.rb
+Loaded suite tc_simple_number2
+Started
+F..
+Finished in 0.038617 seconds.
+
+  1) Failure:
+test_failure(TestSimpleNumber) [tc_simple_number2.rb:16]:
+Adding doesn't work.
+<3> expected but was
+<4>.
+
+3 tests, 4 assertions, 1 failures, 0 errors
+
+-- Java Junit
+.......F.
+Time: 0,003
+There was 1 failure:
+1) testCapacity(junit.samples.VectorTest)junit.framework.AssertionFailedError
+    at junit.samples.VectorTest.testCapacity(VectorTest.java:87)
+    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+
+FAILURES!!!
+Tests run: 8,  Failures: 1,  Errors: 0
+
+
+-- Maven
+
+# mvn test
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running math.AdditionTest
+Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed:
+0.03 sec <<< FAILURE!
+
+Results :
+
+Failed tests:
+  testLireSymbole(math.AdditionTest)
+
+Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
+
+
+-- LuaUnit
+---- non verbose
+* display . or F or E when running tests
+---- verbose
+* display test name + ok/fail
+----
+* blank line
+* number) ERROR or FAILURE: TestName
+   Stack trace
+* blank line
+* number) ERROR or FAILURE: TestName
+   Stack trace
+
+then --------------
+then "Ran x tests in 0.000s (%d not selected, %d skipped)"
+then OK or FAILED (failures=1, error=1)
+
+
+]]
+
+local TextOutput = genericOutput.new() -- derived class
+local TextOutput_MT = { __index = TextOutput } -- metatable
+TextOutput.__class__ = 'TextOutput'
+
+    function TextOutput.new(runner)
+        local t = genericOutput.new(runner, M.VERBOSITY_DEFAULT)
+        t.errorList = {}
+        return setmetatable( t, TextOutput_MT )
+    end
+
+    function TextOutput:startSuite()
+        if self.verbosity > M.VERBOSITY_DEFAULT then
+            print( 'Started on '.. self.result.startDate )
+        end
+    end
+
+    function TextOutput:startTest(testName)
+        if self.verbosity > M.VERBOSITY_DEFAULT then
+            io.stdout:write( "    ", self.result.currentNode.testName, " ... " )
+        end
+    end
+
+    function TextOutput:endTest( node )
+        if node:isPassed() then
+            if self.verbosity > M.VERBOSITY_DEFAULT then
+                io.stdout:write("Ok\n")
+            else
+                io.stdout:write(".")
+            end
+        else
+            if self.verbosity > M.VERBOSITY_DEFAULT then
+                print( node.status )
+                print( node.msg )
+                --[[
+                -- find out when to do this:
+                if self.verbosity > M.VERBOSITY_DEFAULT then
+                    print( node.stackTrace )
+                end
+                ]]
+            else
+                -- write only the first character of status
+                io.stdout:write(string.sub(node.status, 1, 1))
+            end
+        end
+    end
+
+    function TextOutput:displayOneFailedTest( index, fail )
+        print(index..") "..fail.testName )
+        print( fail.msg )
+        print( fail.stackTrace )
+        print()
+    end
+
+    function TextOutput:displayFailedTests()
+        if self.result.notPassedCount ~= 0 then
+            print("Failed tests:")
+            print("-------------")
+            for i, v in ipairs(self.result.notPassed) do
+                self:displayOneFailedTest(i, v)
+            end
+        end
+    end
+
+    function TextOutput:endSuite()
+        if self.verbosity > M.VERBOSITY_DEFAULT then
+            print("=========================================================")
+        else
+            print()
+        end
+        self:displayFailedTests()
+        print( M.LuaUnit.statusLine( self.result ) )
+        if self.result.notPassedCount == 0 then
+            print('OK')
+        end
+    end
+
+-- class TextOutput end
+
+
+----------------------------------------------------------------
+--                     class NilOutput
+----------------------------------------------------------------
+
+local function nopCallable()
+    --print(42)
+    return nopCallable
+end
+
+local NilOutput = { __class__ = 'NilOuptut' } -- class
+local NilOutput_MT = { __index = nopCallable } -- metatable
+
+function NilOutput.new(runner)
+    return setmetatable( { __class__ = 'NilOutput' }, NilOutput_MT )
+end
+
+----------------------------------------------------------------
+--
+--                     class LuaUnit
+--
+----------------------------------------------------------------
+
+M.LuaUnit = {
+    outputType = TextOutput,
+    verbosity = M.VERBOSITY_DEFAULT,
+    __class__ = 'LuaUnit'
+}
+local LuaUnit_MT = { __index = M.LuaUnit }
+
+if EXPORT_ASSERT_TO_GLOBALS then
+    LuaUnit = M.LuaUnit
+end
+
+    function M.LuaUnit.new()
+        return setmetatable( {}, LuaUnit_MT )
+    end
+
+    -----------------[[ Utility methods ]]---------------------
+
+    function M.LuaUnit.asFunction(aObject)
+        -- return "aObject" if it is a function, and nil otherwise
+        if 'function' == type(aObject) then
+            return aObject
+        end
+    end
+
+    function M.LuaUnit.splitClassMethod(someName)
+        --[[
+        Return a pair of className, methodName strings for a name in the form
+        "class.method". If no class part (or separator) is found, will return
+        nil, someName instead (the latter being unchanged).
+
+        This convention thus also replaces the older isClassMethod() test:
+        You just have to check for a non-nil className (return) value.
+        ]]
+        local separator = string.find(someName, '.', 1, true)
+        if separator then
+            return someName:sub(1, separator - 1), someName:sub(separator + 1)
+        end
+        return nil, someName
+    end
+
+    function M.LuaUnit.isMethodTestName( s )
+        -- return true is the name matches the name of a test method
+        -- default rule is that is starts with 'Test' or with 'test'
+        return string.sub(s, 1, 4):lower() == 'test'
+    end
+
+    function M.LuaUnit.isTestName( s )
+        -- return true is the name matches the name of a test
+        -- default rule is that is starts with 'Test' or with 'test'
+        return string.sub(s, 1, 4):lower() == 'test'
+    end
+
+    function M.LuaUnit.collectTests()
+        -- return a list of all test names in the global namespace
+        -- that match LuaUnit.isTestName
+
+        local testNames = {}
+        for k, _ in pairs(_G) do
+            if type(k) == "string" and M.LuaUnit.isTestName( k ) then
+                table.insert( testNames , k )
+            end
+        end
+        table.sort( testNames )
+        return testNames
+    end
+
+    function M.LuaUnit.parseCmdLine( cmdLine )
+        -- parse the command line
+        -- Supported command line parameters:
+        -- --verbose, -v: increase verbosity
+        -- --quiet, -q: silence output
+        -- --error, -e: treat errors as fatal (quit program)
+        -- --output, -o, + name: select output type
+        -- --pattern, -p, + pattern: run test matching pattern, may be repeated
+        -- --exclude, -x, + pattern: run test not matching pattern, may be repeated
+        -- --shuffle, -s, : shuffle tests before reunning them
+        -- --name, -n, + fname: name of output file for junit, default to stdout
+        -- --repeat, -r, + num: number of times to execute each test
+        -- [testnames, ...]: run selected test names
+        --
+        -- Returns a table with the following fields:
+        -- verbosity: nil, M.VERBOSITY_DEFAULT, M.VERBOSITY_QUIET, M.VERBOSITY_VERBOSE
+        -- output: nil, 'tap', 'junit', 'text', 'nil'
+        -- testNames: nil or a list of test names to run
+        -- exeRepeat: num or 1
+        -- pattern: nil or a list of patterns
+        -- exclude: nil or a list of patterns
+
+        local result, state = {}, nil
+        local SET_OUTPUT = 1
+        local SET_PATTERN = 2
+        local SET_EXCLUDE = 3
+        local SET_FNAME = 4
+        local SET_REPEAT = 5
+
+        if cmdLine == nil then
+            return result
+        end
+
+        local function parseOption( option )
+            if option == '--help' or option == '-h' then
+                result['help'] = true
+                return
+            elseif option == '--version' then
+                result['version'] = true
+                return
+            elseif option == '--verbose' or option == '-v' then
+                result['verbosity'] = M.VERBOSITY_VERBOSE
+                return
+            elseif option == '--quiet' or option == '-q' then
+                result['verbosity'] = M.VERBOSITY_QUIET
+                return
+            elseif option == '--error' or option == '-e' then
+                result['quitOnError'] = true
+                return
+            elseif option == '--failure' or option == '-f' then
+                result['quitOnFailure'] = true
+                return
+            elseif option == '--shuffle' or option == '-s' then
+                result['shuffle'] = true
+                return
+            elseif option == '--output' or option == '-o' then
+                state = SET_OUTPUT
+                return state
+            elseif option == '--name' or option == '-n' then
+                state = SET_FNAME
+                return state
+            elseif option == '--repeat' or option == '-r' then
+                state = SET_REPEAT
+                return state
+            elseif option == '--pattern' or option == '-p' then
+                state = SET_PATTERN
+                return state
+            elseif option == '--exclude' or option == '-x' then
+                state = SET_EXCLUDE
+                return state
+            end
+            error('Unknown option: '..option,3)
+        end
+
+        local function setArg( cmdArg, state )
+            if state == SET_OUTPUT then
+                result['output'] = cmdArg
+                return
+            elseif state == SET_FNAME then
+                result['fname'] = cmdArg
+                return
+            elseif state == SET_REPEAT then
+                result['exeRepeat'] = tonumber(cmdArg)
+                                     or error('Malformed -r argument: '..cmdArg)
+                return
+            elseif state == SET_PATTERN then
+                if result['pattern'] then
+                    table.insert( result['pattern'], cmdArg )
+                else
+                    result['pattern'] = { cmdArg }
+                end
+                return
+            elseif state == SET_EXCLUDE then
+                local notArg = '!'..cmdArg
+                if result['pattern'] then
+                    table.insert( result['pattern'],  notArg )
+                else
+                    result['pattern'] = { notArg }
+                end
+                return
+            end
+            error('Unknown parse state: '.. state)
+        end
+
+
+        for i, cmdArg in ipairs(cmdLine) do
+            if state ~= nil then
+                setArg( cmdArg, state, result )
+                state = nil
+            else
+                if cmdArg:sub(1,1) == '-' then
+                    state = parseOption( cmdArg )
+                else
+                    if result['testNames'] then
+                        table.insert( result['testNames'], cmdArg )
+                    else
+                        result['testNames'] = { cmdArg }
+                    end
+                end
+            end
+        end
+
+        if result['help'] then
+            M.LuaUnit.help()
+        end
+
+        if result['version'] then
+            M.LuaUnit.version()
+        end
+
+        if state ~= nil then
+            error('Missing argument after '..cmdLine[ #cmdLine ],2 )
+        end
+
+        return result
+    end
+
+    function M.LuaUnit.help()
+        print(M.USAGE)
+        os.exit(0)
+    end
+
+    function M.LuaUnit.version()
+        print('LuaUnit v'..M.VERSION..' by Philippe Fremy <phil@freehackers.org>')
+        os.exit(0)
+    end
+
+----------------------------------------------------------------
+--                     class NodeStatus
+----------------------------------------------------------------
+
+    local NodeStatus = { __class__ = 'NodeStatus' } -- class
+    local NodeStatus_MT = { __index = NodeStatus } -- metatable
+    M.NodeStatus = NodeStatus
+
+    -- values of status
+    NodeStatus.PASS  = 'PASS'
+    NodeStatus.FAIL  = 'FAIL'
+    NodeStatus.ERROR = 'ERROR'
+
+    function NodeStatus.new( number, testName, className )
+        local t = { number = number, testName = testName, className = className }
+        setmetatable( t, NodeStatus_MT )
+        t:pass()
+        return t
+    end
+
+    function NodeStatus:pass()
+        self.status = self.PASS
+        -- useless but we know it's the field we want to use
+        self.msg = nil
+        self.stackTrace = nil
+    end
+
+    function NodeStatus:fail(msg, stackTrace)
+        self.status = self.FAIL
+        self.msg = msg
+        self.stackTrace = stackTrace
+    end
+
+    function NodeStatus:error(msg, stackTrace)
+        self.status = self.ERROR
+        self.msg = msg
+        self.stackTrace = stackTrace
+    end
+
+    function NodeStatus:isPassed()
+        return self.status == NodeStatus.PASS
+    end
+
+    function NodeStatus:isNotPassed()
+        -- print('hasFailure: '..prettystr(self))
+        return self.status ~= NodeStatus.PASS
+    end
+
+    function NodeStatus:isFailure()
+        return self.status == NodeStatus.FAIL
+    end
+
+    function NodeStatus:isError()
+        return self.status == NodeStatus.ERROR
+    end
+
+    function NodeStatus:statusXML()
+        if self:isError() then
+            return table.concat(
+                {'            <error type="', xmlEscape(self.msg), '">\n',
+                 '                <![CDATA[', xmlCDataEscape(self.stackTrace),
+                 ']]></error>\n'})
+        elseif self:isFailure() then
+            return table.concat(
+                {'            <failure type="', xmlEscape(self.msg), '">\n',
+                 '                <![CDATA[', xmlCDataEscape(self.stackTrace),
+                 ']]></failure>\n'})
+        end
+        return '            <passed/>\n' -- (not XSD-compliant! normally shouldn't get here)
+    end
+
+    --------------[[ Output methods ]]-------------------------
+
+    local function conditional_plural(number, singular)
+        -- returns a grammatically well-formed string "%d <singular/plural>"
+        local suffix = ''
+        if number ~= 1 then -- use plural
+            suffix = (singular:sub(-2) == 'ss') and 'es' or 's'
+        end
+        return string.format('%d %s%s', number, singular, suffix)
+    end
+
+    function M.LuaUnit.statusLine(result)
+        -- return status line string according to results
+        local s = {
+            string.format('Ran %d tests in %0.3f seconds',
+                          result.runCount, result.duration),
+            conditional_plural(result.passedCount, 'success'),
+        }
+        if result.notPassedCount > 0 then
+            if result.failureCount > 0 then
+                table.insert(s, conditional_plural(result.failureCount, 'failure'))
+            end
+            if result.errorCount > 0 then
+                table.insert(s, conditional_plural(result.errorCount, 'error'))
+            end
+        else
+            table.insert(s, '0 failures')
+        end
+        if result.nonSelectedCount > 0 then
+            table.insert(s, string.format("%d non-selected", result.nonSelectedCount))
+        end
+        return table.concat(s, ', ')
+    end
+
+    function M.LuaUnit:startSuite(testCount, nonSelectedCount)
+        self.result = {
+            testCount = testCount,
+            nonSelectedCount = nonSelectedCount,
+            passedCount = 0,
+            runCount = 0,
+            currentTestNumber = 0,
+            currentClassName = "",
+            currentNode = nil,
+            suiteStarted = true,
+            startTime = os.clock(),
+            startDate = os.date(os.getenv('LUAUNIT_DATEFMT')),
+            startIsodate = os.date('%Y-%m-%dT%H:%M:%S'),
+            patternIncludeFilter = self.patternIncludeFilter,
+            tests = {},
+            failures = {},
+            errors = {},
+            notPassed = {},
+        }
+
+        self.outputType = self.outputType or TextOutput
+        self.output = self.outputType.new(self)
+        self.output:startSuite()
+    end
+
+    function M.LuaUnit:startClass( className )
+        self.result.currentClassName = className
+        self.output:startClass( className )
+    end
+
+    function M.LuaUnit:startTest( testName  )
+        self.result.currentTestNumber = self.result.currentTestNumber + 1
+        self.result.runCount = self.result.runCount + 1
+        self.result.currentNode = NodeStatus.new(
+            self.result.currentTestNumber,
+            testName,
+            self.result.currentClassName
+        )
+        self.result.currentNode.startTime = os.clock()
+        table.insert( self.result.tests, self.result.currentNode )
+        self.output:startTest( testName )
+    end
+
+    function M.LuaUnit:addStatus( err )
+        -- "err" is expected to be a table / result from protectedCall()
+        if err.status == NodeStatus.PASS then
+            return
+        end
+
+        local node = self.result.currentNode
+
+        --[[ As a first approach, we will report only one error or one failure for one test.
+
+        However, we can have the case where the test is in failure, and the teardown is in error.
+        In such case, it's a good idea to report both a failure and an error in the test suite. This is
+        what Python unittest does for example. However, it mixes up counts so need to be handled carefully: for
+        example, there could be more (failures + errors) count that tests. What happens to the current node ?
+
+        We will do this more intelligent version later.
+        ]]
+
+        -- if the node is already in failure/error, just don't report the new error (see above)
+        if node.status ~= NodeStatus.PASS then
+            return
+        end
+
+        if err.status == NodeStatus.FAIL then
+            node:fail( err.msg, err.trace )
+            table.insert( self.result.failures, node )
+        elseif err.status == NodeStatus.ERROR then
+            node:error( err.msg, err.trace )
+            table.insert( self.result.errors, node )
+        end
+
+        if node:isFailure() or node:isError() then
+            -- add to the list of failed tests (gets printed separately)
+            table.insert( self.result.notPassed, node )
+        end
+        self.output:addStatus( node )
+    end
+
+    function M.LuaUnit:endTest()
+        local node = self.result.currentNode
+        -- print( 'endTest() '..prettystr(node))
+        -- print( 'endTest() '..prettystr(node:isNotPassed()))
+        node.duration = os.clock() - node.startTime
+        node.startTime = nil
+        self.output:endTest( node )
+
+        if node:isPassed() then
+            self.result.passedCount = self.result.passedCount + 1
+        elseif node:isError() then
+            if self.quitOnError or self.quitOnFailure then
+                -- Runtime error - abort test execution as requested by
+                -- "--error" option. This is done by setting a special
+                -- flag that gets handled in runSuiteByInstances().
+                print("\nERROR during LuaUnit test execution:\n" .. node.msg)
+                self.result.aborted = true
+            end
+        elseif node:isFailure() then
+            if self.quitOnFailure then
+                -- Failure - abort test execution as requested by
+                -- "--failure" option. This is done by setting a special
+                -- flag that gets handled in runSuiteByInstances().
+                print("\nFailure during LuaUnit test execution:\n" .. node.msg)
+                self.result.aborted = true
+            end
+        end
+        self.result.currentNode = nil
+    end
+
+    function M.LuaUnit:endClass()
+        self.output:endClass()
+    end
+
+    function M.LuaUnit:endSuite()
+        if self.result.suiteStarted == false then
+            error('LuaUnit:endSuite() -- suite was already ended' )
+        end
+        self.result.duration = os.clock()-self.result.startTime
+        self.result.suiteStarted = false
+
+        -- Expose test counts for outputter's endSuite(). This could be managed
+        -- internally instead, but unit tests (and existing use cases) might
+        -- rely on these fields being present.
+        self.result.notPassedCount = #self.result.notPassed
+        self.result.failureCount = #self.result.failures
+        self.result.errorCount = #self.result.errors
+
+        self.output:endSuite()
+    end
+
+    function M.LuaUnit:setOutputType(outputType)
+        -- default to text
+        -- tap produces results according to TAP format
+        if outputType:upper() == "NIL" then
+            self.outputType = NilOutput
+            return
+        end
+        if outputType:upper() == "TAP" then
+            self.outputType = TapOutput
+            return
+        end
+        if outputType:upper() == "JUNIT" then
+            self.outputType = JUnitOutput
+            return
+        end
+        if outputType:upper() == "TEXT" then
+            self.outputType = TextOutput
+            return
+        end
+        error( 'No such format: '..outputType,2)
+    end
+
+    --------------[[ Runner ]]-----------------
+
+    function M.LuaUnit:protectedCall(classInstance, methodInstance, prettyFuncName)
+        -- if classInstance is nil, this is just a function call
+        -- else, it's method of a class being called.
+
+        local function err_handler(e)
+            -- transform error into a table, adding the traceback information
+            return {
+                status = NodeStatus.ERROR,
+                msg = e,
+                trace = string.sub(debug.traceback("", 3), 2)
+            }
+        end
+
+        local ok, err
+        if classInstance then
+            -- stupid Lua < 5.2 does not allow xpcall with arguments so let's use a workaround
+            ok, err = xpcall( function () methodInstance(classInstance) end, err_handler )
+        else
+            ok, err = xpcall( function () methodInstance() end, err_handler )
+        end
+        if ok then
+            return {status = NodeStatus.PASS}
+        end
+
+        local iter_msg
+        iter_msg = self.exeRepeat and 'iteration '..self.currentCount
+
+        err.msg, err.status = M.adjust_err_msg_with_iter( err.msg, iter_msg )
+
+        if err.status == NodeStatus.PASS then
+            err.trace = nil
+            return err
+        end
+
+        -- reformat / improve the stack trace
+        if prettyFuncName then -- we do have the real method name
+            err.trace = err.trace:gsub("in (%a+) 'methodInstance'", "in %1 '"..prettyFuncName.."'")
+        end
+        if STRIP_LUAUNIT_FROM_STACKTRACE then
+            err.trace = stripLuaunitTrace(err.trace)
+        end
+
+        return err -- return the error "object" (table)
+    end
+
+
+    function M.LuaUnit:execOneFunction(className, methodName, classInstance, methodInstance)
+        -- When executing a test function, className and classInstance must be nil
+        -- When executing a class method, all parameters must be set
+
+        if type(methodInstance) ~= 'function' then
+            error( tostring(methodName)..' must be a function, not '..type(methodInstance))
+        end
+
+        local prettyFuncName
+        if className == nil then
+            className = '[TestFunctions]'
+            prettyFuncName = methodName
+        else
+            prettyFuncName = className..'.'..methodName
+        end
+
+        if self.lastClassName ~= className then
+            if self.lastClassName ~= nil then
+                self:endClass()
+            end
+            self:startClass( className )
+            self.lastClassName = className
+        end
+
+        self:startTest(prettyFuncName)
+
+        local node = self.result.currentNode
+        for iter_n = 1, self.exeRepeat or 1 do
+            if node:isNotPassed() then
+                break
+            end
+            self.currentCount = iter_n
+
+            -- run setUp first (if any)
+            if classInstance then
+                local func = self.asFunction( classInstance.setUp ) or
+                             self.asFunction( classInstance.Setup ) or
+                             self.asFunction( classInstance.setup ) or
+                             self.asFunction( classInstance.SetUp )
+                if func then
+                    self:addStatus(self:protectedCall(classInstance, func, className..'.setUp'))
+                end
+            end
+
+            -- run testMethod()
+            if node:isPassed() then
+                self:addStatus(self:protectedCall(classInstance, methodInstance, prettyFuncName))
+            end
+
+            -- lastly, run tearDown (if any)
+            if classInstance then
+                local func = self.asFunction( classInstance.tearDown ) or
+                             self.asFunction( classInstance.TearDown ) or
+                             self.asFunction( classInstance.teardown ) or
+                             self.asFunction( classInstance.Teardown )
+                if func then
+                    self:addStatus(self:protectedCall(classInstance, func, className..'.tearDown'))
+                end
+            end
+        end
+
+        self:endTest()
+    end
+
+    function M.LuaUnit.expandOneClass( result, className, classInstance )
+        --[[
+        Input: a list of { name, instance }, a class name, a class instance
+        Ouptut: modify result to add all test method instance in the form:
+        { className.methodName, classInstance }
+        ]]
+        for methodName, methodInstance in sortedPairs(classInstance) do
+            if M.LuaUnit.asFunction(methodInstance) and M.LuaUnit.isMethodTestName( methodName ) then
+                table.insert( result, { className..'.'..methodName, classInstance } )
+            end
+        end
+    end
+
+    function M.LuaUnit.expandClasses( listOfNameAndInst )
+        --[[
+        -- expand all classes (provided as {className, classInstance}) to a list of {className.methodName, classInstance}
+        -- functions and methods remain untouched
+
+        Input: a list of { name, instance }
+
+        Output:
+        * { function name, function instance } : do nothing
+        * { class.method name, class instance }: do nothing
+        * { class name, class instance } : add all method names in the form of (className.methodName, classInstance)
+        ]]
+        local result = {}
+
+        for i,v in ipairs( listOfNameAndInst ) do
+            local name, instance = v[1], v[2]
+            if M.LuaUnit.asFunction(instance) then
+                table.insert( result, { name, instance } )
+            else
+                if type(instance) ~= 'table' then
+                    error( 'Instance must be a table or a function, not a '..type(instance)..' with value '..prettystr(instance))
+                end
+                local className, methodName = M.LuaUnit.splitClassMethod( name )
+                if className then
+                    local methodInstance = instance[methodName]
+                    if methodInstance == nil then
+                        error( "Could not find method in class "..tostring(className).." for method "..tostring(methodName) )
+                    end
+                    table.insert( result, { name, instance } )
+                else
+                    M.LuaUnit.expandOneClass( result, name, instance )
+                end
+            end
+        end
+
+        return result
+    end
+
+    function M.LuaUnit.applyPatternFilter( patternIncFilter, listOfNameAndInst )
+        local included, excluded = {}, {}
+        for i, v in ipairs( listOfNameAndInst ) do
+            -- local name, instance = v[1], v[2]
+            if  patternFilter( patternIncFilter, v[1] ) then
+                table.insert( included, v )
+            else
+                table.insert( excluded, v )
+            end
+        end
+        return included, excluded
+    end
+
+    function M.LuaUnit:runSuiteByInstances( listOfNameAndInst )
+        --[[ Run an explicit list of tests. Each item of the list must be one of:
+        * { function name, function instance }
+        * { class name, class instance }
+        * { class.method name, class instance }
+        ]]
+
+        local expandedList = self.expandClasses( listOfNameAndInst )
+        if self.shuffle then
+            randomizeTable( expandedList )
+        end
+        local filteredList, filteredOutList = self.applyPatternFilter(
+            self.patternIncludeFilter, expandedList )
+
+        self:startSuite( #filteredList, #filteredOutList )
+
+        for i,v in ipairs( filteredList ) do
+            local name, instance = v[1], v[2]
+            if M.LuaUnit.asFunction(instance) then
+                self:execOneFunction( nil, name, nil, instance )
+            else
+                -- expandClasses() should have already taken care of sanitizing the input
+                assert( type(instance) == 'table' )
+                local className, methodName = M.LuaUnit.splitClassMethod( name )
+                assert( className ~= nil )
+                local methodInstance = instance[methodName]
+                assert(methodInstance ~= nil)
+                self:execOneFunction( className, methodName, instance, methodInstance )
+            end
+            if self.result.aborted then
+                break -- "--error" or "--failure" option triggered
+            end
+        end
+
+        if self.lastClassName ~= nil then
+            self:endClass()
+        end
+
+        self:endSuite()
+
+        if self.result.aborted then
+            print("LuaUnit ABORTED (as requested by --error or --failure option)")
+            os.exit(-2)
+        end
+    end
+
+    function M.LuaUnit:runSuiteByNames( listOfName )
+        --[[ Run LuaUnit with a list of generic names, coming either from command-line or from global
+            namespace analysis. Convert the list into a list of (name, valid instances (table or function))
+            and calls runSuiteByInstances.
+        ]]
+
+        local instanceName, instance
+        local listOfNameAndInst = {}
+
+        for i,name in ipairs( listOfName ) do
+            local className, methodName = M.LuaUnit.splitClassMethod( name )
+            if className then
+                instanceName = className
+                instance = _G[instanceName]
+
+                if instance == nil then
+                    error( "No such name in global space: "..instanceName )
+                end
+
+                if type(instance) ~= 'table' then
+                    error( 'Instance of '..instanceName..' must be a table, not '..type(instance))
+                end
+
+                local methodInstance = instance[methodName]
+                if methodInstance == nil then
+                    error( "Could not find method in class "..tostring(className).." for method "..tostring(methodName) )
+                end
+
+            else
+                -- for functions and classes
+                instanceName = name
+                instance = _G[instanceName]
+            end
+
+            if instance == nil then
+                error( "No such name in global space: "..instanceName )
+            end
+
+            if (type(instance) ~= 'table' and type(instance) ~= 'function') then
+                error( 'Name must match a function or a table: '..instanceName )
+            end
+
+            table.insert( listOfNameAndInst, { name, instance } )
+        end
+
+        self:runSuiteByInstances( listOfNameAndInst )
+    end
+
+    function M.LuaUnit.run(...)
+        -- Run some specific test classes.
+        -- If no arguments are passed, run the class names specified on the
+        -- command line. If no class name is specified on the command line
+        -- run all classes whose name starts with 'Test'
+        --
+        -- If arguments are passed, they must be strings of the class names
+        -- that you want to run or generic command line arguments (-o, -p, -v, ...)
+
+        local runner = M.LuaUnit.new()
+        return runner:runSuite(...)
+    end
+
+    function M.LuaUnit:runSuite( ... )
+
+        local args = {...}
+        if type(args[1]) == 'table' and args[1].__class__ == 'LuaUnit' then
+            -- run was called with the syntax M.LuaUnit:runSuite()
+            -- we support both M.LuaUnit.run() and M.LuaUnit:run()
+            -- strip out the first argument
+            table.remove(args,1)
+        end
+
+        if #args == 0 then
+            args = cmdline_argv
+        end
+
+        local options = pcall_or_abort( M.LuaUnit.parseCmdLine, args )
+
+        -- We expect these option fields to be either `nil` or contain
+        -- valid values, so it's safe to always copy them directly.
+        self.verbosity     = options.verbosity
+        self.quitOnError   = options.quitOnError
+        self.quitOnFailure = options.quitOnFailure
+        self.fname         = options.fname
+
+        self.exeRepeat            = options.exeRepeat
+        self.patternIncludeFilter = options.pattern
+        self.shuffle              = options.shuffle
+
+        if options.output then
+            if options.output:lower() == 'junit' and options.fname == nil then
+                print('With junit output, a filename must be supplied with -n or --name')
+                os.exit(-1)
+            end
+            pcall_or_abort(self.setOutputType, self, options.output)
+        end
+
+        self:runSuiteByNames( options.testNames or M.LuaUnit.collectTests() )
+
+        return self.result.notPassedCount
+    end
+-- class LuaUnit
+
+-- For compatbility with LuaUnit v2
+M.run = M.LuaUnit.run
+M.Run = M.LuaUnit.run
+
+function M:setVerbosity( verbosity )
+    M.LuaUnit.verbosity = verbosity
+end
+M.set_verbosity = M.setVerbosity
+M.SetVerbosity = M.setVerbosity
+
+
+return M

--- a/lua/lib/timeline.lua
+++ b/lua/lib/timeline.lua
@@ -1,0 +1,234 @@
+--- timeline sequencer
+-- hotrod some clock & sequins structures for rapid playability
+
+--- globals are available on crow, otherwise require for norns
+local s = sequins or require 'lib/sequins'
+local clk = clock or require 'clock'
+
+local TL = {launch_default = 1}
+
+-- create a timeline object from a table
+function TL.new(t)
+    return setmetatable({ lq = t.lq or TL.launch_default
+                        , qd = t.qd or false
+                        }, TL)
+end
+
+function TL.is_timeline(t) return getmetatable(t) == TL end
+
+function TL.hotswap(old, new)
+    if type(old) == 'table' then
+        if TL.is_timeline(old) then
+            if TL.is_timeline(new) then -- tl for tl
+                TL.hotswap(old.t, new.t)
+                new:stop() -- ensure a new timeline doesn't run!
+                -- TODO hotswap other elements of the timeline
+            else -- put the new data table in existing tl
+                TL.hotswap(old.t, new)
+            end
+        elseif s.is_sequins(old) then old:settable(new) -- sequins
+        else -- regular table
+            for k,v in pairs(old) do
+                old[k] = TL.hotswap(v, new[k])
+            end
+        end
+    else return new end -- return updated value
+    -- TODO nested timelines
+    return old
+end
+
+
+-- helper fns
+local realize = function(q)
+    if s.is_sequins(q) then return q() else return q end
+end
+local apply = function(fn, ...) fn(...) end
+local bsleep = function(v) clk.sleep(clk.get_beat_sec()*v) end
+local isfn = function(f) return (type(f) == 'function') end
+
+-- abstract fns that handle value realizeization & fn application
+local doact = function(fn)
+    fn = realize(fn)
+    if type(fn) == 'string' then return fn -- strings are keywords
+    elseif isfn(fn) then return fn() -- call it directly
+    else -- table of fn & args
+        local t = {} -- make a copy to avoid changing sequins
+        for i=1,#fn do t[i] = realize(fn[i]) end
+        return apply(table.unpack(t))
+    end
+end
+
+local dowait = function(d, z) -- duration, zero
+    local z = z+realize(d)
+    clk.sync(z)
+    return z
+end
+
+local doalign = function(b, z)
+    local now = clk.get_beats()
+    local ct = now - z -- zero-ref'd current time
+    b = realize(b)
+    if ct < b then bsleep(b-ct) end
+end
+
+-- like doalign, but in seconds rather than beats
+local doaligns = function(b, z)
+    b = realize(b) -- timestamp to wait until
+    if b > z then
+        clk.sleep(b-z) -- wait until the perfect moment
+        return b -- return current time
+    else return z end -- otherwise return time now
+end
+
+local dopred = function(p)
+    p = realize(p) -- realize sequins value
+    if isfn(p) then return p() else return p end
+end
+
+
+--- pre-methods (chain into :loop etc)
+-- works in all tl modes
+
+-- launch quantization to lock to a clock.sync
+function TL.launch(q) return TL.new{lq = q} end
+function TL:_launch(q) self.lq = q; return self end
+
+-- stops auto-play
+function TL.queue() return TL.new{qd = true} end
+function TL:_queue() self.qd = true; return self end
+
+
+--- loop
+-- standalone
+function TL.loop(t) return TL.new{}:loop(t) end
+
+-- method version
+function TL:_loop(t)
+    self.mode = 'loop'
+    self.t = t -- capture table
+    self.fn = function()
+        self.i = 0 -- iteration 0 before quant finished
+        clk.sync(self.lq) -- launch quantization
+        self.z = math.floor(clk.get_beats()) -- reference beat to stop drift
+        repeat
+            self.i = self.i + 1
+            for i=1,#self.t,2 do
+                doact(self.t[i+1])
+                self.z = dowait(self.t[i], self.z)
+            end
+        until(dopred(self.p or false))
+    end
+    if not self.qd then TL.play(self) end
+    return self
+end
+
+-- shortcut for a loop that begins stopped
+function TL.qloop(t) return TL.queue():loop(t) end
+
+-- loop predicate methods
+function TL:unless(pred)
+    self.p = pred
+    return self -- method chain
+end
+function TL:times(n)
+    self._times = n
+    self.p = function()
+        n = n - 1
+        return (n <= 0) -- true at minimum count
+    end
+    return self -- method chain
+end
+
+
+--- score
+-- standalone
+function TL.score(t) return TL.new{}:score(t) end
+
+-- method version
+function TL:_score(t)
+    self.mode = 'score'
+    self.t = t -- capture table
+    self.fn = function()
+        local now = clk.get_beats()
+        local lq = self.lq
+        self.z = now + (lq - (now % lq)) -- calculate beat-zero
+        ::_R:: -- NOTE: self.z must already be updated!
+        for i=1,#self.t,2 do
+            doalign(self.t[i], self.z)
+            if doact(self.t[i+1]) == 'reset' then
+                self.z = self.z + self.t[i] -- increment beat-zero by 'reset' marker
+                goto _R
+            end
+        end
+    end
+    if not self.qd then TL.play(self) end
+    return self
+end
+
+
+---real 
+-- standalone
+function TL.real(t) return TL.new{}:real(t) end
+
+-- method version
+function TL:_real(t)
+    self.mode = 'real'
+    self.t = t -- capture table
+    self.fn = function()
+        clk.sync(self.lq) -- launch quantization
+        ::_R::
+        self.z = 0 -- tracks elapsed time as 0 is arbitrary
+        for i=1,#self.t,2 do
+            self.z = doaligns(self.t[i], self.z) -- track current loop time
+            if doact(self.t[i+1]) == 'reset' then goto _R end
+        end
+    end
+    if not self.qd then TL.play(self) end
+    return self
+end
+
+
+--- post methods for operating on any tl object
+
+-- stop a playing timeline
+-- NOTE: doesn't destroy the timeline. allows it to be restarted with :play
+function TL:stop()
+    if self.coro then -- check the coroutine exists (won't if not yet :play'd)
+        clk.cancel(self.coro)
+    end
+end
+
+-- play a queued timeline
+function TL:play()
+    self:stop() -- stop the timeline, and restart
+    if self._times then -- if has :times method, refresh the self.p pred-fn
+        self:times(self._times)
+    end
+    self.coro = clk.run(self.fn)
+end
+
+-- return count of loop repetitions inclusive
+function TL:iter() return self.i end
+
+-- alias clock cleanup to stop all running timelines
+TL.cleanup = clk.cleanup
+
+--- metamethods
+TL.mms = { stop   = TL.stop
+         , unless = TL.unless
+         , times  = TL.times
+         , once   = TL.once
+         , loop   = TL._loop
+         , score  = TL._score
+         , real   = TL._real
+         , play   = TL.play
+         , iter   = TL.iter
+         , hotswap= TL.hotswap
+         , launch = TL._launch
+         , queue  = TL._queue
+         }
+TL.__index = TL.mms
+
+setmetatable(TL, TL)
+
+return TL

--- a/lua/lib/voice.lua
+++ b/lua/lib/voice.lua
@@ -1,0 +1,185 @@
+--- experimental voice allocation module
+-- @module lib.voice
+
+
+-- (voice) Slot class
+local Slot = {}
+Slot.__index = Slot
+
+function Slot.new(pool, id)
+	local o = setmetatable({}, Slot)
+	o.pool = pool
+	o.id = id
+	o.active = false
+	o.on_release = nil
+	o.on_steal = nil
+	return o
+end
+
+function Slot:release()
+	self.pool:release(self)
+end
+
+
+-- Rotate allocation class
+local Rotate = {}
+Rotate.__index = Rotate
+
+function Rotate.new(polyphony, slots)
+	local o = setmetatable({}, Rotate)
+	o.polyphony = polyphony
+	o.slots = slots
+	o.n = 0
+	return o
+end
+
+function Rotate:next()
+	-- voices isn't used
+	local i = self.n + 1
+	if i > self.polyphony then
+		i = 1
+	end
+	self.n = i
+	return self.slots[i]
+end
+
+
+-- Random allocation class
+local Random = {}
+Random.__index = Random
+
+function Random.new(polyphony, slots)
+	local o = setmetatable({}, Random)
+	o.polyphony = polyphony
+	o.slots = slots
+	return o
+end
+
+function Random:next()
+	-- voices isn't used
+	return self.slots[math.random(self.polyphony)]
+end
+
+
+-- LRU allocation class
+local LRU = {}
+LRU.__index = LRU
+
+function LRU.new(polyphony, slots)
+	local o = setmetatable({}, LRU)
+	o.slots = slots
+	o.count = 0
+	for _, s in pairs(slots) do
+		s.n = 0    -- yuck: add field to slot
+	end
+	return o
+end
+
+function LRU:next()
+	local count = self.count + 1
+	local next = self.slots[1]
+	local free = nil
+
+	self.count = count
+
+	for _, slot in pairs(self.slots) do
+		if not slot.active then
+			if free == nil or slot.n < free.n then
+				free = slot
+			end
+		elseif slot.n < next.n then
+			next = slot
+		end
+	end
+
+	-- choose free voice if possible
+	if free then next = free end
+	next.n = count
+	return next
+end
+
+-- Voice class
+local Voice = {}
+Voice.__index = Voice
+
+-- constants
+Voice.MODE_ROTATE = 1
+Voice.MODE_LRU = 2
+Voice.MODE_RANDOM = 3
+
+--- create a new Voice
+-- @tparam number polyphony
+-- @tparam number mode
+-- @treturn Voice
+function Voice.new(polyphony, mode)
+	local o = setmetatable({}, Voice)
+	o.polyphony = polyphony
+	o.mode = mode
+	o.will_steal = nil      -- event callback
+	o.will_release = nil     -- event callback
+	o.pairings = {}
+	local slots = {}
+	for id = 1, polyphony do
+		slots[id] = Slot.new(o, id)
+	end
+	if mode == Voice.MODE_ROTATE then
+		o.style = Rotate.new(polyphony, slots)
+	elseif mode == Voice.MODE_RANDOM then
+		o.style = Random.new(polyphony, slots)
+	else
+		o.style = LRU.new(polyphony, slots)
+	end
+	return o
+end
+
+--- get next available voice Slot from pool, stealing an active slot if needed
+function Voice:get()
+	local slot = self.style:next()
+	if slot.active then
+		if self.will_steal then self.will_steal(slot) end
+
+		-- ack; nuke any existing pairings
+		for key, value in pairs(self.pairings) do
+			if value == slot then
+				self.pairings[key] = nil
+				break
+			end
+		end
+
+		if slot.on_steal then 
+			slot.on_steal(slot)
+		elseif slot.on_release then
+			slot.on_release(slot)
+		end
+	end
+	slot.active = true
+	return slot
+end
+
+
+--- push
+function Voice:push(key, slot)
+	self.pairings[key] = slot
+end
+
+--- pop
+function Voice:pop(key)
+	local slot = self.pairings[key]
+	self.pairings[key] = nil
+	return slot
+end
+
+--- return voice slot to pool
+-- @param slot : a Slot obtained from get()
+function Voice:release(slot)
+	if slot.pool == self then
+		if self.will_release then self.will_release(slot) end
+		if slot.on_release then slot.on_release(slot) end
+		slot.active = false
+	else
+		print("voice slot: ", slot, "does not belong to pool: ", self)
+	end
+end
+
+
+return Voice


### PR DESCRIPTION
added all the generic libs from [`norns/lua/lib`](https://github.com/monome/norns/tree/main/lua/lib), except:
- [`graph`](https://github.com/monome/norns/blob/main/lua/lib/graph.lua) and its derivatives: they depend on stuff not yet implemented is seamstress' screen API. 
- [`ui`](https://github.com/monome/norns/blob/main/lua/lib/ui.lua), [`textentry`](https://github.com/monome/norns/blob/main/lua/lib/textentry.lua), [`fileselect`](https://github.com/monome/norns/blob/main/lua/lib/fileselect.lua) and [`listselect`](https://github.com/monome/norns/blob/main/lua/lib/listselect.lua): all the UI stuff too tied to norns' screen & its limitations

all the rest should just work i guess. i'm not 100% sure about `lfo`, as it relies on the params API but i've included it nonetheless (should be easy to tweak to make it work).

also, couldn't add those 2 fns:
- `util.trim_string_to_width` (depends on `_norns.screen_text_extents`)
- `util.time` (depends on `_norns.get_time`)

also added the `include` fn as an alias to `require` in the `config.lua` as its omnipresent in norns' script (in place of `require`) and having this small alias makes porting norns scripts easier.

---

also, please note that this switches back the name of the module table of `util` / `tabutil` from `Util` / `Tab` to `util` / `tab`. idk why you switched style initially. my understanding is that people tend to use an uppercase 1rst letter when the module defines a class and a lowercase for when it's all static fns.