### PR TITLE
fix: `params:add{}`

### DIFF
--- a/lua/core/params.lua
+++ b/lua/core/params.lua
@@ -56,23 +56,24 @@ function ParamSet:add(args)
     local name = args.name or id
 
     if args.type == "number"  then
-      param = self:add_number(id, name, args.min, args.max, args.default, args.units)
+      self:add_number(id, name, args.min, args.max, args.default, args.units)
     elseif args.type == "option" then
-      param = self:add_option(id, name, args.options, args.default)
+      self:add_option(id, name, args.options, args.default)
     elseif args.type == "control" then
-      param = self:add_control(id, name, args.controlspec, args.formatter)
+      self:add_control(id, name, args.controlspec, args.formatter)
     elseif args.type == "binary" then
-      param = self:add_binary(id, name, args.behavior or 'toggle', args.default)
+      self:add_binary(id, name, args.behavior or 'toggle', args.default)
     elseif args.type == "trigger" then
-      param = self:add_trigger(id, name)
+      self:add_trigger(id, name)
     elseif args.type == "separator" then
-      param = separator.new(id, name)
+      self:add_separator(id, name)
     elseif args.type == "group" then
-      param = group.new(id, name, args.n)
+      self:add_group(id, name, args.n)
     else
       print("paramset.add() error: unknown type")
-      return nil
     end
+
+    return nil
   end
 
   local overwrite = true


### PR DESCRIPTION
previously, running `params.add` with table arguments, i.e.:
```
params:add{
    type = 'number', id = 'octave_'..chan, name = 'octave',
    min = -2, max = 2, default = 0,
    action = actions.rate_start_end
}
```
yielded this error:
```
 /usr/local/share/seamstress/lua/core/params.lua:79: attempt to index a nil value (local 'param')
stack traceback:
        /Users/and/sc-extensions/grvl-seamstress/script.lua:18: in main chunk
        [C]: in function 'require'
        /usr/local/share/seamstress/lua/core/seamstress.lua:49: in function '_startup'

```
because the `add_<type>` functions in this new take of `params.lua` don't return a param instance, but just call back into `params:add` with their instances. so I just added a `return` & let recursion do it's thing – this was the most unobtrusive fix, but maybe the back & forth feels a bit funky.

(cc @dndrks , I gather they wrote most/all of this bit !)