### PR TITLE
fix: switch `params:add_binary` argument order to match norns

### DIFF
--- a/lua/core/params.lua
+++ b/lua/core/params.lua
@@ -141,9 +141,9 @@ end
 --- add binary.
 -- @tparam string id (no spaces)
 -- @tparam string name (can contain spaces)
--- @tparam integer default 0 or 1
 -- @tparam string behavior "toggle" or "trigger" or "momentary"; defaults to "toggle"
-function ParamSet:add_binary(id, name, default, behavior)
+-- @tparam integer default 0 or 1
+function ParamSet:add_binary(id, name, behavior, default)
 	self:add { param = binary.new(id, name, behavior or "toggle", default) }
 end
 


### PR DESCRIPTION
I noticed that in #31 I had flipped the argument order used for `ParamSet:add_binary`, but I also noticed that [norns' `ParamSet`](https://github.com/monome/norns/blob/c5adf1cb64184c48c429c7b6c9fb9e90f2833d86/lua/core/paramset.lua#L255) actually uses the argument order that I had used by mistake, so I just updated seamstress to match norns – I'm assuming the flip-flop was non-intentional