### PR TITLE
fix: `params:add` sets action

### DIFF
--- a/lua/core/params.lua
+++ b/lua/core/params.lua
@@ -71,6 +71,11 @@ function ParamSet:add(args)
       self:add_group(id, name, args.n)
     else
       print("paramset.add() error: unknown type")
+      return nil
+    end
+
+    if args.action then
+      self:set_action(id, args.action)
     end
 
     return nil
@@ -108,9 +113,6 @@ function ParamSet:add(args)
     self.lookup[param.id] = self.count
   end
   self.hidden[self.count] = false
-  if args.action then
-    param.action = args.action
-  end
 end
 
 --- add number.


### PR DESCRIPTION
eee srry for the noise, should've tested #31 a little more before submitting. this just sets the action function when the arg is provided via `params:add`

I've `add`-ed & messed with a good number of params now so hopefully I've caught everything !