### PR TITLE
feat: `include`

### DIFF
--- a/lua/config.lua
+++ b/lua/config.lua
@@ -24,3 +24,20 @@ path = {
 }
 
 _old_print = print
+
+function include(file)
+  -- local dirs = {norns.state.path, _path.code, _path.extn}
+  local dirs = {path.pwd, path.seamstress_home}
+  for _, dir in ipairs(dirs) do
+    local p = dir..'/'..file..'.lua'
+    -- if util.file_exists(p) then
+    if util.exists(p) then
+      print("including "..p)
+      return dofile(p)
+    end
+  end
+
+  -- didn't find anything
+  print("### MISSING INCLUDE: "..file)
+  error("MISSING INCLUDE: "..file,2)
+end

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -27,7 +27,7 @@ _old_print = print
 
 function include(file)
   -- local dirs = {norns.state.path, _path.code, _path.extn}
-  local dirs = {path.pwd, path.seamstress}
+  local dirs = {seamstress.state.path, path.pwd, path.seamstress}
   for _, dir in ipairs(dirs) do
     local p = dir..'/'..file..'.lua'
     -- if util.file_exists(p) then

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -27,7 +27,7 @@ _old_print = print
 
 function include(file)
   -- local dirs = {norns.state.path, _path.code, _path.extn}
-  local dirs = {path.pwd, path.seamstress_home}
+  local dirs = {path.pwd, path.seamstress}
   for _, dir in ipairs(dirs) do
     local p = dir..'/'..file..'.lua'
     -- if util.file_exists(p) then

--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -49,16 +49,32 @@ _seamstress.monome = {
 
 --- startup function; called by spindle to start the script.
 -- @tparam string script_file set by calling seamstress with `-s filename`
-_startup = function(script_file)
-	if not util.exists(script_file .. ".lua") and not util.exists(path.seamstress .. "/" .. script_file .. ".lua") then
-		print("seamstress was unable to find user-provided " .. script_file .. ".lua file!")
-		print("create such a file and place it in either CWD or ~/seamstress")
-	else
-		require(script_file)
-	end
-	clock.add_params()
-	init()
-	paramsMenu.init()
+_startup = function (script_file)
+  local filename
+  if util.exists(script_file..'.lua') then
+    filename = string.sub(script_file,1,1) == "/" and script_file or os.getenv("PWD").."/"..script_file
+  elseif util.exists(path.seamstress .. '/' .. script_file .. '.lua') then
+    filename = path.seamstress .. '/' .. script_file
+  else
+    print("seamstress was unable to find user-provided " .. script_file .. ".lua file!")
+    print("create such a file and place it in either CWD or ~/seamstress")
+  end
+
+  if filename then
+    filename = filename .. '.lua'
+    path, scriptname = filename:match("^(.*)/([^.]*).*$")
+
+    seamstress.state.script = filename
+    seamstress.state.path = path
+    seamstress.state.name = scriptname
+    seamstress.state.shortname = seamstress.state.name:match( "([^/]+)$" )
+
+    require(script_file)
+  end
+
+  clock.add_params()
+  init()
+  paramsMenu.init()
 end
 
 _seamstress.cleanup = function()


### PR DESCRIPTION
norns provide the [`include`](https://github.com/monome/norns/blob/main/lua/core/startup.lua#L37-L50) helper, that works like `require` but doesn't cache (uses `dofile`) and allows sourcing libs from the current script's folder (e.g. `include("/lib/toto")`).

most norns script rely on it instead of `require` for their own modules. having this helper fn would help porting norns libs to seamstress.

this PR also introduces `seamstress.state.path`, the path of the current script's folder (needed for requiring from current script's path).

as an added bonus we also get `seamstress.state.script` (absolute path to current script) and `seamstress.state.name` (script file name sans ext), behaving like norns' `norns.state.<var>`.