### PR TITLE
fix: shutdown smoothly without requiring terminal reset; print goodbye

### DIFF
--- a/src/input.zig
+++ b/src/input.zig
@@ -36,7 +36,7 @@ pub fn deinit() void {
 fn input_run() !void {
     _ = c.rl_initialize();
     c.rl_prep_terminal(1);
-    defer c.rl_deprep_terminal();
+    defer _ = c.rl_reset_terminal(null);
     c.using_history();
     c.stifle_history(500);
     const home = std.os.getenv("HOME");

--- a/src/main.zig
+++ b/src/main.zig
@@ -105,6 +105,16 @@ pub fn main() !void {
         defer if (args.watch and filepath != null) watcher.deinit();
     }
     std.io.getStdIn().close();
+    try print_goodbye();
+    std.io.getStdOut().close();
+}
+
+fn print_goodbye() !void {
+    const stdout_file = std.io.getStdOut().writer();
+    var bw = std.io.bufferedWriter(stdout_file);
+    const stdout = bw.writer();
+    try stdout.print("SEAMSTRESS: goodbye\n", .{});
+    try bw.flush();
 }
 
 fn print_version() !void {


### PR DESCRIPTION
closes (#42)