### PR TITLE
MIDI learn + pmap's

### DIFF
--- a/lua/core/menu/params-menu.lua
+++ b/lua/core/menu/params-menu.lua
@@ -1,12 +1,13 @@
 -- params menu
 
 --[[
-  based on the norn's params menu
+  based on norns' params menu
   norns params menu first committed by @artfwo April 8, 2018
   reimagined for seamstress by @dndrks June 26, 2023
 ]]
 
 local mEDIT = 1
+local mMAP = 2
 
 local paramsWindow = 2
 
@@ -19,7 +20,7 @@ local m = {
   mode = mEDIT,
   mode_pos = 1,
   map = false,
-  mpos = 1,
+  midi_learn = { pos = 0, state = false },
   dev = 1,
   ch = 1,
   cc = 100,
@@ -33,7 +34,6 @@ local m = {
 }
 
 local page
-local mode_item = { "EDIT >", "PSET >", "MAP >" }
 local pset = {}
 
 -- called from menu on script reset
@@ -73,7 +73,16 @@ end
 
 m.key = function(char, modifiers, is_repeat, state)
   -- encapsulates both encoder + key interactions from norns...
-  if m.mode == mEDIT then
+  if #modifiers == 1 and modifiers[1] == "shift" and char == "m" and state == 1 then
+    m.mode = m.mode == mEDIT and mMAP or mEDIT
+    if m.group then
+      build_sub(m.groupid)
+    else
+      build_page()
+    end
+  end
+
+  if m.mode == mEDIT or m.mode == mMAP then
     local i = page[m.pos + 1]
     local t = params:t(i)
     if (char.name == "up" or char.name == "down") and state == 1 then
@@ -91,11 +100,14 @@ m.key = function(char, modifiers, is_repeat, state)
           end
         until params:t(page[i]) == params.tSEPARATOR or i == 1
         m.pos = i - 1
+        m.midi_learn.pos = m.pos
       else
         -- delta 1
         local d = char.name == "up" and -1 or 1
         local prev = m.pos
         m.pos = util.clamp(m.pos + d, 0, #page - 1)
+        m.midi_learn.pos = m.pos
+        m.midi_learn.state = false
         if m.pos ~= prev then
           m.redraw()
         end
@@ -108,8 +120,8 @@ m.key = function(char, modifiers, is_repeat, state)
         params:delta(page[m.pos + 1], dx)
       end
     elseif char.name == "return" then
-      -- enter group
       if state == 1 then
+        -- enter group
         if t == params.tGROUP then
           build_sub(i)
           m.group = true
@@ -117,6 +129,7 @@ m.key = function(char, modifiers, is_repeat, state)
           m.groupname = params:string(i)
           m.oldpos = m.pos
           m.pos = 0
+        -- jump separator
         elseif t == params.tSEPARATOR then
           local n = m.pos + 1
           repeat
@@ -126,6 +139,21 @@ m.key = function(char, modifiers, is_repeat, state)
             end
           until params:t(page[n]) == params.tSEPARATOR
           m.pos = n - 1
+        -- midi learn
+        elseif m.mode == mMAP and params:get_allow_pmap(i) then
+          local n = params:get_id(i)
+          local pm = params:lookup_param(n).midi_mapping
+
+          m.midi_learn.pos = m.pos
+          if pm.dev == nil then
+            m.midi_learn.state = not m.midi_learn.state
+            if m.midi_learn.state then
+              pmap.new(n)
+              pm = params:lookup_param(n).midi_mapping
+            end
+          else
+            m.midi_learn.state = false
+          end
         end
       end
     elseif char.name == "rshift" then
@@ -133,7 +161,11 @@ m.key = function(char, modifiers, is_repeat, state)
     elseif char.name == "ralt" then
       m.coarse = state == 1
     elseif char.name == "backspace" then
-      if state == 1 then
+      if tab.contains(modifiers, "shift") and state == 1 then
+        if m.mode == mMAP then
+          pmap.remove(i)
+        end
+      elseif state == 1 then
         if m.group == true then
           m.group = false
           build_page()
@@ -145,10 +177,16 @@ m.key = function(char, modifiers, is_repeat, state)
   m.redraw()
 end
 
+m.newtext = function(txt)
+  if txt ~= "cancel" then
+    params:set(page[m.pos + 1], txt)
+    m.redraw()
+  end
+end
+
 m.redraw = function()
   screen.set(paramsWindow)
   screen.clear()
-  -- _menu.draw_panel()
 
   if m.mode == mEDIT then
     local n = "PARAMETERS"
@@ -184,9 +222,106 @@ m.redraw = function()
         end
       end
     end
+  elseif m.mode == mMAP then
+    local n = "PARAMETERS: MAPPING"
+    if m.group then
+      n = n .. " / " .. m.groupname
+    end
+    screen.color(130, 140, 140, 255)
+    screen.move(10, 10)
+    screen.text(n)
+    screen.move_rel(0, 20)
+    for i = 1, 20 do
+      if (i > 1 - m.pos) and (i < #page - m.pos + 2) then
+        if i == 2 then
+          screen.color(m.highlightColors.r, m.highlightColors.g, m.highlightColors.b)
+        else
+          screen.color(130, 140, 140, 255)
+        end
+        local p = page[i + m.pos - 1]
+        local t = params:t(p)
+        local n = params:get_name(p)
+        local id = params:get_id(p)
+        screen.move_rel(0, 10)
+        if t == params.tSEPARATOR then
+          screen.text(n)
+          screen.move_rel(0, 8)
+          screen.line_rel(127, 0)
+          screen.move_rel(0, -8)
+        elseif t == params.tGROUP then
+          screen.text(n .. " >")
+        else
+          screen.text(id)
+          screen.move_rel(127, 0)
+          if params:get_allow_pmap(id) then
+            local pm = params:lookup_param(id).midi_mapping
+            if pm.dev then
+              screen.text_right("CC:" .. pm.cc .. " | CH:" .. pm.ch .. " | DEV:" .. pm.dev)
+            elseif m.midi_learn.state and i == 2 then
+              screen.text_right("[learning]")
+            else
+              screen.text_right("-")
+            end
+          end
+          screen.move_rel(-127, 0)
+        end
+      end
+    end
   end
+
   screen.refresh()
   screen.reset()
+end
+
+m.menu_midi_event = function(data, dev)
+  if data.type == "cc" then
+    local ch = data.ch
+    local cc = data.cc
+    local v = data.val
+    if m.midi_learn.state then
+      m.midi_learn.state = false
+      m.dev = dev
+      m.ch = ch
+      m.cc = cc
+      local p = page[m.pos + 1]
+      local id = params:get_id(p)
+      pmap.assign(id, m.dev, m.ch, m.cc)
+      m.redraw()
+    else
+      local r = pmap.rev[dev][ch][cc]
+      for param_target = 1, #r do
+        local d = r[param_target]
+        local prm_id = d
+        d = params:lookup_param(prm_id).midi_mapping
+        local t = params:t(prm_id)
+        if d.accum then
+          v = (v > 64) and 1 or -1
+          d.value = util.clamp(d.value + v, d.in_lo, d.in_hi)
+          v = d.value
+        end
+        local s = util.clamp(v, d.in_lo, d.in_hi)
+        s = util.linlin(d.in_lo, d.in_hi, d.out_lo, d.out_hi, s)
+        if t == params.tCONTROL or t == params.tTAPER then
+          params:set_raw(prm_id, s)
+        elseif t == params.tNUMBER or t == params.tOPTION then
+          s = util.round(s)
+          params:set(prm_id, s)
+        elseif t == params.tBINARY then
+          params:delta(prm_id, s)
+          for i, param in ipairs(params.params) do
+            if params:lookup_param(i).behavior == params:lookup_param(prm_id).behavior then
+              if params:lookup_param(i).behavior == "trigger" then
+                m.triggered[i] = 2
+              else
+                m.on[i] = params:get(i)
+              end
+            end
+          end
+        end
+      end
+      m.redraw()
+    end
+  end
 end
 
 m.init = function()

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -480,6 +480,7 @@ _seamstress.midi = {
         if Midi.vinports[d.port].event then
           Midi.vinports[d.port].event(timestamp, bytes)
         end
+        paramsMenu.menu_midi_event(Midi.to_msg(bytes), d.port)
       end
     else
       error("no entry for midi " .. id)

--- a/lua/core/params.lua
+++ b/lua/core/params.lua
@@ -119,6 +119,8 @@ function ParamSet:add(args)
     self.lookup[param.id] = self.count
   end
   self.hidden[self.count] = false
+
+  self:lookup_param(param.id).midi_mapping = {}
 end
 
 --- add number.

--- a/lua/core/pmap.lua
+++ b/lua/core/pmap.lua
@@ -1,0 +1,121 @@
+-- parameter map
+
+--[[
+  based on norns' pmap.lua
+  norns pmap.lua first committed by @tehn March 19, 2020
+  rewritten for seamstress by @dndrks Aug 15, 2023
+]]
+
+local pmap = {
+  data = {},
+  rev = {},
+}
+
+pmap.__index = pmap
+
+function pmap.new(id)
+  local p = params:lookup_param(id)
+  p.midi_mapping = {
+    in_lo = 0,
+    in_hi = 127,
+    out_lo = 0,
+    out_hi = 1,
+    accum = false,
+    echo = false,
+    value = 0,
+  }
+  pmap.data[id] = p.midi_mapping
+end
+
+function pmap.remove(id)
+  local p = params:lookup_param(id)
+  if p.midi_mapping.dev ~= nil then
+    local to_remove = tab.key(pmap.rev[p.midi_mapping.dev][p.midi_mapping.ch][p.midi_mapping.cc], id)
+    table.remove(pmap.rev[p.midi_mapping.dev][p.midi_mapping.ch][p.midi_mapping.cc], to_remove)
+    p.midi_mapping.dev = nil
+    p.midi_mapping.ch = nil
+    p.midi_mapping.cc = nil
+  end
+end
+
+function pmap.assign(id, dev, ch, cc)
+  local p = params:lookup_param(id)
+  p.midi_mapping.dev = dev
+  p.midi_mapping.ch = ch
+  p.midi_mapping.cc = cc
+  table.insert(pmap.rev[dev][ch][cc], id)
+  pmap.write()
+end
+
+function pmap.refresh()
+  for k, v in pairs(pmap.data) do
+    table.insert(pmap.rev[v.dev][v.ch][v.cc], k)
+    local p = params:lookup_param(k)
+    for item, val in pairs(v) do
+      p.midi_mapping[item] = val
+    end
+  end
+end
+
+function pmap.clear()
+  pmap.data = {}
+  pmap.rev = {}
+  -- build reverse lookup table: dev -> ch -> cc
+  for dev = 1, 16 do
+    pmap.rev[dev] = {}
+    for ch = 1, 16 do
+      pmap.rev[dev][ch] = {}
+      for cc = 0, 127 do
+        pmap.rev[dev][ch][cc] = {}
+      end
+    end
+  end
+end
+
+function pmap.write()
+  local function quote(s)
+    return '"' .. s:gsub('"', '\\"') .. '"'
+  end
+  local filename = seamstress.state.path .. "/" .. seamstress.state.name .. ".pmap"
+  print(">> saving PMAP " .. filename)
+  local fd = io.open(filename, "w+")
+  io.output(fd)
+  local line = ""
+  for k, v in pairs(pmap.data) do
+    line = string.format('%s:"{', quote(tostring(k)))
+    for x, y in pairs(v) do
+      line = line .. x .. "=" .. tostring(y) .. ", "
+    end
+    line = line:sub(1, -3) .. '}"\n'
+    io.write(line)
+    line = ""
+  end
+  io.close(fd)
+end
+
+function pmap.read()
+  local function unquote(s)
+    return s:gsub('^"', ""):gsub('"$', ""):gsub('\\"', '"')
+  end
+  local filename = seamstress.state.path .. "/" .. seamstress.state.name .. ".pmap"
+  local fd = io.open(filename, "r")
+  print(">> loading MIDI mapping: " .. filename)
+  if fd then
+    io.close(fd)
+    for line in io.lines(filename) do
+      local name, value = string.match(line, '(".-")%s*:%s*(.*)')
+      if name and value and tonumber(value) == nil then
+        local x = load("return " .. unquote(value))
+        pmap.data[unquote(name)] = x()
+      end
+    end
+    pmap.refresh()
+    print(">> MIDI mapping loaded!")
+  else
+    print(">> MIDI mapping file not present, using defaults")
+  end
+end
+
+pmap.clear()
+
+return pmap

--- a/lua/core/pmap.lua
+++ b/lua/core/pmap.lua
@@ -75,10 +75,12 @@ function pmap.clear()
 end
 
 function pmap.write()
+  local filepath = path.seamstress .. "/data/" .. seamstress.state.name
+  util.make_dir(filepath)
   local function quote(s)
     return '"' .. s:gsub('"', '\\"') .. '"'
   end
-  local filename = seamstress.state.path .. "/" .. seamstress.state.name .. ".pmap"
+  local filename = filepath .. "/" .. seamstress.state.name .. ".pmap"
   print(">> saving PMAP " .. filename)
   local fd = io.open(filename, "w+")
   io.output(fd)
@@ -99,9 +101,10 @@ function pmap.read()
   local function unquote(s)
     return s:gsub('^"', ""):gsub('"$', ""):gsub('\\"', '"')
   end
-  local filename = seamstress.state.path .. "/" .. seamstress.state.name .. ".pmap"
+  local filepath = path.seamstress .. "/data/" .. seamstress.state.name
+  local filename = filepath .. "/" .. seamstress.state.name .. ".pmap"
   local fd = io.open(filename, "r")
-  print(">> loading MIDI mapping: " .. filename)
+  print(">> searching for MIDI mapping: " .. filename)
   if fd then
     io.close(fd)
     for line in io.lines(filename) do
@@ -112,7 +115,7 @@ function pmap.read()
       end
     end
     pmap.refresh()
-    print(">> MIDI mapping loaded!")
+    print(">> MIDI mapping file found, loaded!")
   else
     print(">> MIDI mapping file not present, using defaults")
   end

--- a/lua/core/pmap.lua
+++ b/lua/core/pmap.lua
@@ -30,11 +30,13 @@ end
 function pmap.remove(id)
   local p = params:lookup_param(id)
   if p.midi_mapping.dev ~= nil then
-    local to_remove = tab.key(pmap.rev[p.midi_mapping.dev][p.midi_mapping.ch][p.midi_mapping.cc], id)
+    local to_remove = tab.key(pmap.rev[p.midi_mapping.dev][p.midi_mapping.ch][p.midi_mapping.cc], p.id)
     table.remove(pmap.rev[p.midi_mapping.dev][p.midi_mapping.ch][p.midi_mapping.cc], to_remove)
+    pmap.data[p.id] = nil
     p.midi_mapping.dev = nil
     p.midi_mapping.ch = nil
     p.midi_mapping.cc = nil
+    pmap.write()
   end
 end
 

--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -18,6 +18,7 @@ clock = require("core/clock")
 controlspec = require("core/controlspec")
 paramset = require("core/params")
 paramsMenu = require("core/menu/params-menu")
+pmap = require("core/pmap")
 params = paramset.new()
 print = _seamstress.print
 
@@ -72,9 +73,13 @@ _startup = function(script_file)
     require(script_file)
   end
 
+  params:clear()
+  pmap.clear()
+
   clock.add_params()
   init()
   paramsMenu.init()
+  pmap.read()
   return seamstress.state.path
 end
 


### PR DESCRIPTION
## summary
this PR introduces keyboard-driven MIDI learn functionality, with supplementary `.pmap` generation and automatic reading at script load :)

## lingering q's
re: the `.pmap` workflow, i'm curious if it'd be useful to centralize *all* script-generated seamstress data under `<path.seamstress>/data/<seamstress.state.name>/`? on the one hand, i kinda dig all the script-generated data tracing along the invocation, but this seems more of a convenience for someone _using_ a script -- as a script author, i might want to play from my git folder and not worry about keeping it `data`-free.

totally open to any ideas you have @ryleelyman !

## details

### MIDI mapping

**enter mapping UI**: while running a script, focus the params screen and press <kbd>SHIFT</kbd> + <kbd>M</kbd> to toggle between the params UI and the mapping UI:
<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/91157f4b-520f-401e-8b5f-5f4ec7e66bd6">

**toggle MIDI learn**: press <kbd>ENTER</kbd> on any unassigned entry (any with a `-`) to toggle MIDI learn:
<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/4cb12955-d30a-4879-ab3e-44db662759bb">

**wiggle control**: once seamstress receives a MIDI CC on any channel / number / device, it will register the assignment and save a `.pmap` file in the `seamstress.state.path`:
<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/3153fedd-0c46-4491-9724-78dd979854cc">

**delete an assignment**: in mapping mode, any learned parameter can be cleared with <kbd>SHIFT</kbd> + <kbd>BACKSPACE</kbd>

### `.pmap`'s

**write**
whenever a mapping is established, a `.pmap` file is automatically generated with the corresponding data. the `.pmap`'s filename is built as: `seamstress.state.path .. "/" .. seamstress.state.name .. ".pmap"`. to write on-demand: `pmap.write()`

**read**
whenever a `.pmap` file with the above pattern is detected in `seamstress.state.path .. "/" .. seamstress.state.name`, it will be loaded at script launch. to read on-demand: `pmap.read()`