### PR TITLE
feat: launch script not in pwd

### DIFF
--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -92,7 +92,7 @@ _startup = function(script_file)
       end
     end
 
-    require(script_file)
+    dofile(filename)
   end
 
   params:clear()


### PR DESCRIPTION
currently, `seamstress -s <script>` only works for launching scripts located in PWD.

this PR allows calling `seamstress -s other_dir/<script>` (relative path) or even `seamstress -s /home/me/other_dir/<script>` (absolute path).