### PR TITLE
feat: allow `include` to work on path including script's parent folder

### DIFF
--- a/lua/config.lua
+++ b/lua/config.lua
@@ -25,12 +25,16 @@ path = {
 _old_print = print
 
 --- include
+-- inspired by norns' version
+-- norns does the lookup in the following dirs: norns.state.path, _path.code, _path.extn
 function include(file)
-  -- local dirs = {norns.state.path, _path.code, _path.extn}
   local dirs = { seamstress.state.path, path.pwd, path.seamstress }
+  -- case prefixed w/ script folder's name (equivalent to norns' _path.code)
+  if string.match(file, "^(%w+)/") == string.match(seamstress.state.path, "/(%w+)$") then
+    table.insert(dirs, 2, seamstress.state.path.."/..")
+  end
   for _, dir in ipairs(dirs) do
     local p = dir .. "/" .. file .. ".lua"
-    -- if util.file_exists(p) then
     if util.exists(p) then
       print("including " .. p)
       return dofile(p)


### PR DESCRIPTION
this PR allows seamstress' `include` to work even closer to norns'.

indeed on norns, inside a script `~/dust/code/script/script.lua`, to require `~/dust/code/script/lib/lib.lua`, one can use:
- `include("lib/lib.lua")` (relative to script dir)
- `include("script/lib/lib.lua")` (relative to `~/dust/code/`)

this PR adds support for the 2nd form, by conditionally adding in the paths looked up by `include` the script parent folder if it's present ad the 1rst element in the path passed as argument.