### PR TITLE
feat: add MIDI map editing

### DIFF
--- a/examples/hello_pmaps.lua
+++ b/examples/hello_pmaps.lua
@@ -1,0 +1,135 @@
+-- hello_pmaps.lua
+-- introduces how to MIDI map and manage mapping files (known as PMAPs)
+
+-- a script's mapping file is written every time a mapping is created or edited,
+--    and when a PSET is saved (see hello_psets.lua).
+
+-- this file is saved to your seamstress path, under 'data/<scriptname>/<scriptname>.pmap'
+
+-- MAPPING:
+-- while running a script, focus the params screen and press SHIFT + M to toggle
+--   between the params UI and the mapping UI.
+-- press ENTER on any unassigned entry (any with a -) to toggle MIDI learn.
+-- once seamstress receives a MIDI CC on any channel / number / device,
+--    it will register the assignment and save a .pmap file in the seamstress.state.path
+-- in mapping mode, any learned parameter can be cleared with SHIFT + BACKSPACE.
+
+-- MAPPING EDIT:
+-- while in mapping mode, press ENTER on any mapped parameter to open the mapping for editing.
+-- here, you can manually modify:
+--   - CC
+--   - channel
+--   - device
+--   - out: lowest parameter value (scales incoming CC value to this range)
+--   - out: highest parameter value (scales incoming CC value to this range)
+--   - in: lowest incoming value (any CC lower than this value will not affect the parameter)
+--   - in: highest incoming value (any CC higher than this value will not affect the parameter)
+--   - accum: enable when using relative / delta-based CC streams
+--   - echo: enable to send the parameter's (scaled) value back to the mapped controller (for LED activity)
+-- in MAPPING EDIT mode, you can use these keys:
+--   - left/right: nav
+--   - up/down: delta +/- 1
+--   - right ALT + up/down: delta +/- 10
+--   - TAB: cycle to next parameter
+--   - SHIFT + TAB: cycle to previous parameter
+
+-- SCRIPTING:
+-- all of these commands refer to:
+--   path.seamstress .. "/data/" .. seamstress.state.name .. "/" .. seamstress.state.name .. ".pmap"
+-- to write on-demand: pmap.write()
+-- to read on-demand: pmap.read()
+-- to delete on-demand: pmap.delete()
+
+function init()
+  header = function(text)
+    screen.color(182, 66, 38)
+    screen.text(text)
+  end
+
+  instruction = function(text)
+    screen.color(70, 138, 168)
+    screen.text(text)
+  end
+
+  params:add_separator("hello PMAPs!")
+  params:add {
+    type = "number",
+    id = "mappable_number",
+    name = "you can map this!",
+    min = 0,
+    max = 10,
+    default = 8,
+  }
+
+  params:add {
+    type = "option",
+    id = "mappable_option",
+    name = "or this!",
+    options = { "yes", "yep", "yeh!" },
+  }
+
+  params:add {
+    type = "binary",
+    id = "mappable_binary",
+    behavior = "trigger",
+    name = "me too!",
+  }
+
+  params:add {
+    type = "control",
+    id = "mappable_control",
+    name = "map map map!",
+    controlspec = controlspec.FREQ,
+  }
+
+  params:add_separator("unmappable params")
+  params:add {
+    type = "number",
+    id = "unmappable_number",
+    name = "can't map!",
+    min = 0,
+    max = 10,
+    default = 0,
+    allow_pmap = false,
+  }
+  params:add {
+    type = "option",
+    id = "unmappable_option",
+    name = "can't map this either!",
+    options = { "nope", "nah", "nothin'" },
+    allow_pmap = false,
+  }
+  params:add {
+    type = "binary",
+    id = "unmappable_binary",
+    name = "truly, unmappable",
+    allow_pmap = false,
+  }
+  params:add {
+    type = "control",
+    id = "unmappable_control",
+    name = "keep movin'",
+    controlspec = controlspec.FREQ,
+    allow_pmap = false,
+  }
+
+  redraw()
+end
+
+function redraw()
+  screen.clear()
+  screen.move(10, 10)
+  header("in params window:")
+  screen.move(20, 20)
+  instruction("SHIFT + M: toggle MAPPING")
+  screen.move(10, 35)
+  header("if a parameter is unmapped:")
+  screen.move(20, 45)
+  instruction("ENTER / RETURN: toggle MIDI learn")
+  screen.move(10, 55)
+  header("if a parameter is mapped:")
+  screen.move(20, 65)
+  instruction("ENTER / RETURN: enter mapping management")
+
+  screen.refresh()
+end

--- a/examples/hello_pmaps.lua
+++ b/examples/hello_pmaps.lua
@@ -71,14 +71,36 @@ function init()
   params:add {
     type = "binary",
     id = "mappable_binary",
-    behavior = "trigger",
-    name = "me too!",
+    behavior = "momentary",
+    name = "momentary!",
+    action = function(x)
+      print("hi from momentary", x)
+    end,
+  }
+
+  params:add {
+    type = "trigger",
+    id = "mappable_trigger",
+    name = "trigger!",
+    action = function()
+      print("hi from trigger")
+    end,
+  }
+
+  params:add {
+    type = "binary",
+    id = "mappable_toggle",
+    behavior = "toggle",
+    name = "toggle!",
+    action = function(x)
+      print("hi from toggle", x)
+    end,
   }
 
   params:add {
     type = "control",
     id = "mappable_control",
-    name = "map map map!",
+    name = "control!",
     controlspec = controlspec.FREQ,
   }
 
@@ -86,7 +108,7 @@ function init()
   params:add {
     type = "number",
     id = "unmappable_number",
-    name = "can't map!",
+    name = "you cannot map this!",
     min = 0,
     max = 10,
     default = 0,

--- a/lua/core/menu/params-menu.lua
+++ b/lua/core/menu/params-menu.lua
@@ -211,28 +211,29 @@ m.key = function(char, modifiers, is_repeat, state)
       if params.count > 0 then
         local d = char.name == "left" and -1 or 1
         if t == params.tBINARY then
-          params:delta(i, 1)
           if params:lookup_param(i).behavior == "trigger" then
             if is_repeat == false then
+              params:delta(i, 1)
               m.triggered[i] = 2
             end
+          elseif params:lookup_param(i).behavior == "toggle" then
+            if is_repeat == false then
+              params:delta(i, 1)
+              m.on[i] = params:get(i)
+            end
           else
+            params:delta(i, 1)
             m.on[i] = params:get(i)
           end
-        elseif t == params.tTRIGGER then
-          params:set(i)
-          m.triggered[i] = 2
         else
           local dx = m.fine and (d / 20) or (m.coarse and d * 10 or d)
           params:delta(i, dx)
         end
       end
     elseif (char.name == "right" or char.name == "left") and state == 0 then
-      if t == params.tBINARY then
+      if t == params.tBINARY and params:lookup_param(i).behavior == "momentary" then
         params:delta(i, 0)
-        if params:lookup_param(i).behavior ~= "trigger" then
-          m.on[i] = params:get(i)
-        end
+        m.on[i] = params:get(i)
       end
     elseif char.name == "return" then
       if state == 1 then
@@ -482,18 +483,6 @@ local function draw_binary(param_name, p)
   screen.move_rel(127, 2)
   local fill = m.on[p] or m.triggered[p]
   if fill and fill > 0 then
-    screen.rect_fill(3, 3)
-  end
-  screen.move_rel(-127, -2)
-end
-
-local function draw_trigger(param_name, p)
-  if screen.get_text_size(param_name) > 100 then
-    param_name = util.trim_string_to_width(param_name, 100)
-  end
-  screen.text(param_name)
-  screen.move_rel(127, 2)
-  if m.triggered[p] and m.triggered[p] > 0 then
     screen.rect_fill(3, 3)
   end
   screen.move_rel(-127, -2)

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -395,6 +395,7 @@ function Midi.update_connected_state()
       Midi.vports[i].connected = false
     end
   end
+  pmap.refresh()
 end
 
 _seamstress.midi = {

--- a/lua/core/params.lua
+++ b/lua/core/params.lua
@@ -64,15 +64,15 @@ function ParamSet:add(args)
     local name = args.name or id
 
     if args.type == "number" then
-      self:add_number(id, name, args.min, args.max, args.default, args.units)
+      self:add_number(id, name, args.min, args.max, args.default, args.units, args.allow_pmap)
     elseif args.type == "option" then
-      self:add_option(id, name, args.options, args.default)
+      self:add_option(id, name, args.options, args.default, args.allow_pmap)
     elseif args.type == "control" then
-      self:add_control(id, name, args.controlspec, args.formatter)
+      self:add_control(id, name, args.controlspec, args.formatter, args.allow_pmap)
     elseif args.type == "binary" then
-      self:add_binary(id, name, args.behavior or "toggle", args.default)
+      self:add_binary(id, name, args.behavior or "toggle", args.default, args.allow_pmap)
     elseif args.type == "trigger" then
-      self:add_trigger(id, name)
+      self:add_trigger(id, name, args.allow_pmap)
     elseif args.type == "separator" then
       self:add_separator(id, name)
     elseif args.type == "group" then
@@ -134,18 +134,19 @@ end
 -- @tparam number max maximum value
 -- @tparam number default default / initial value
 -- @tparam string units
-function ParamSet:add_number(id, name, min, max, default, units)
+-- @tparam allow_pmap
+function ParamSet:add_number(id, name, min, max, default, units, allow_pmap)
   local cs = controlspec.new(min, max, "lin", 1, default, units, 1 / math.abs(max - min))
-  self:add { param = control.new(id, name, cs) }
+  self:add { param = control.new(id, name, cs, nil, allow_pmap) }
   params.params[params.lookup[id]].is_number = true
 end
 
 --- add option.
 -- @tparam string id (no spaces)
 -- @tparam string name (can contain spaces)
--- @param options
--- @param default
--- @param allow_pmap
+-- @tparam options
+-- @tparam default
+-- @tparam allow_pmap
 function ParamSet:add_option(id, name, options, default, allow_pmap)
   -- self:add { param=option.new(id, name, options, default) }
   local cs = controlspec.new(1, #options, "lin", 1, default, units, 1 / (#options - 1))
@@ -160,24 +161,28 @@ end
 -- @tparam string name (can contain spaces)
 -- @tparam string behavior "toggle" or "trigger" or "momentary"; defaults to "toggle"
 -- @tparam integer default 0 or 1
-function ParamSet:add_binary(id, name, behavior, default)
-  self:add { param = binary.new(id, name, behavior or "toggle", default) }
+-- @tparam allow_pmap
+function ParamSet:add_binary(id, name, behavior, default, allow_pmap)
+  print(behavior)
+  self:add { param = binary.new(id, name, behavior or "toggle", default, allow_pmap) }
 end
 
 --- add trigger.
 -- @tparam string id (no spaces)
 -- @tparam string name (can contain spaces)
-function ParamSet:add_trigger(id, name)
-  self:add { param = binary.new(id, name, "trigger") }
+-- @tparam allow_pmap
+function ParamSet:add_trigger(id, name, allow_pmap)
+  self:add { param = binary.new(id, name, "trigger", nil, allow_pmap) }
 end
 
 --- add control.
 -- @tparam string id (no spaces)
 -- @tparam string name (can contain spaces)
 -- @tparam controlspec controlspec
--- @param formatter
-function ParamSet:add_control(id, name, controlspec, formatter)
-  self:add { param = control.new(id, name, controlspec, formatter) }
+-- @tparam formatter
+-- @tparam allow_pmap
+function ParamSet:add_control(id, name, controlspec, formatter, allow_pmap)
+  self:add { param = control.new(id, name, controlspec, formatter, allow_pmap) }
 end
 
 --- add text.
@@ -329,7 +334,7 @@ function ParamSet:delta(index, d)
     midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, val))
     if midi_prm.echo then
       local port = pmap.data[param.id].dev
-      midi.voutports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+      midi.vports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
     end
   end
 end

--- a/lua/core/params/binary.lua
+++ b/lua/core/params/binary.lua
@@ -19,7 +19,7 @@ function binary.new(id, name, behavior, default, allow_pmap)
   t.name = name
   t.default = default or 0
   t.value = t.default
-  t.behavior = behavior or "trigger"
+  t.behavior = behavior or "toggle"
   t.action = function() end
   if allow_pmap == nil then
     t.allow_pmap = true

--- a/lua/core/params/control.lua
+++ b/lua/core/params/control.lua
@@ -94,6 +94,14 @@ function Control:set_raw(value, silent)
       self:bang()
     end
   end
+  if pmap.data[self.id] ~= nil then
+    local midi_prm = pmap.data[self.id]
+    midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, self.raw))
+    if midi_prm.echo then
+      local port = pmap.data[self.id].dev
+      midi.voutports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+    end
+  end
 end
 
 --- get_delta.

--- a/lua/core/params/control.lua
+++ b/lua/core/params/control.lua
@@ -99,7 +99,7 @@ function Control:set_raw(value, silent)
     midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, self.raw))
     if midi_prm.echo then
       local port = pmap.data[self.id].dev
-      midi.voutports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+      midi.vports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
     end
   end
 end

--- a/lua/core/pmap.lua
+++ b/lua/core/pmap.lua
@@ -68,7 +68,7 @@ function pmap.refresh()
         midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, val))
         if midi_prm.echo then
           local port = pmap.data[k].dev
-          midi.voutports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+          midi.vports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
         end
       end
     end

--- a/lua/core/pmap.lua
+++ b/lua/core/pmap.lua
@@ -57,6 +57,20 @@ function pmap.refresh()
       for item, val in pairs(v) do
         p.midi_mapping[item] = val
       end
+      local midi_prm = pmap.data[k]
+      if v.echo then
+        local val
+        if p.t == params.tCONTROL then
+          val = params:get_raw(k)
+        else
+          val = params:get(k)
+        end
+        midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, val))
+        if midi_prm.echo then
+          local port = pmap.data[k].dev
+          midi.voutports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+        end
+      end
     end
   end
 end
@@ -100,7 +114,6 @@ function pmap.write()
 end
 
 function pmap.read()
-  if not seamstress.state.name then return end
   local function unquote(s)
     return s:gsub('^"', ""):gsub('"$', ""):gsub('\\"', '"')
   end
@@ -117,11 +130,18 @@ function pmap.read()
         pmap.data[unquote(name)] = x()
       end
     end
-    pmap.refresh()
     print(">> MIDI mapping file found, loaded!")
+    pmap.refresh()
   else
     print(">> MIDI mapping file not present, using defaults")
   end
+end
+
+function pmap.delete()
+  local filepath = path.seamstress .. "/data/" .. seamstress.state.name
+  local filename = filepath .. "/" .. seamstress.state.name .. ".pmap"
+  os.execute("rm " .. filename)
+  print(">> MIDI mapping file deleted: " .. filename)
 end
 
 pmap.clear()

--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -27,6 +27,8 @@ seamstress = {}
 
 seamstress.state = require("core/state")
 
+_menu.timer = metro[36]
+
 --- global init function to be overwritten in user scripts.
 init = function() end
 --- global cleanup function to be overwritten in user scripts.

--- a/lua/lib/formatters.lua
+++ b/lua/lib/formatters.lua
@@ -9,9 +9,8 @@
 local Formatters = {}
 
 local function format(param, value, units)
-  return value.." "..(units or param.controlspec.units or "")
+  return value .. " " .. (units or param.controlspec.units or "")
 end
-
 
 -- Raw
 
@@ -44,12 +43,13 @@ function Formatters.format_secs_raw(secs)
     out_string = util.round(secs, 0.1) .. " s"
   else
     out_string = util.round(secs, 0.01)
-    if string.len(out_string) < 4 then out_string = out_string .. "0" end
+    if string.len(out_string) < 4 then
+      out_string = out_string .. "0"
+    end
     out_string = out_string .. " s"
   end
   return out_string
 end
-
 
 -- Params
 
@@ -62,32 +62,36 @@ end
 --- percentage
 -- @param param
 function Formatters.percentage(param)
-  return format(param, util.round(param:get()*100), "%")
+  return format(param, util.round(param:get() * 100), "%")
 end
 
 --- unipolar_as_percentage
 -- @param param
 function Formatters.unipolar_as_percentage(param)
-  return format(param, util.round(param:get()*100), "%")
+  return format(param, util.round(param:get() * 100), "%")
 end
 
 --- bipolar_as_percentage
 -- @param param
 function Formatters.bipolar_as_percentage(param)
-  return format(param, util.round(param:get()*100), "%")
+  return format(param, util.round(param:get() * 100), "%")
 end
 
 --- secs_as_ms
 -- @param param
 function Formatters.secs_as_ms(param)
-  return format(param, util.round(param:get()*1000), "ms")
+  return format(param, util.round(param:get() * 1000), "ms")
 end
 
 --- unipolar_as_true_false
 -- @param param
 function Formatters.unipolar_as_true_false(param)
   local str
-  if param:get() == 1 then str = "true" else str = "false" end
+  if param:get() == 1 then
+    str = "true"
+  else
+    str = "false"
+  end
   return format(param, str)
 end
 
@@ -95,7 +99,11 @@ end
 -- @param param
 function Formatters.unipolar_as_enabled_disabled(param)
   local str
-  if param:get() == 1 then str = "enabled" else str = "disabled" end
+  if param:get() == 1 then
+    str = "enabled"
+  else
+    str = "disabled"
+  end
   return format(param, str)
 end
 
@@ -105,30 +113,32 @@ function Formatters.bipolar_as_pan_widget(param)
   local dots_per_side = 10
   local widget
   local function add_dots(num_dots)
-    for i=1,num_dots do widget = (widget or "").."." end
+    for i = 1, num_dots do
+      widget = (widget or "") .. "."
+    end
   end
   local function add_bar()
-    widget = (widget or "").."|"
+    widget = (widget or "") .. "|"
   end
 
   local value = param:get()
   local pan_side = math.abs(value)
-  local pan_side_percentage = util.round(pan_side*100)
+  local pan_side_percentage = util.round(pan_side * 100)
   local descr
   local dots_left
   local dots_right
 
   if value > 0 then
-    dots_left = dots_per_side+util.round(pan_side*dots_per_side)
-    dots_right = util.round((1-pan_side)*dots_per_side)
+    dots_left = dots_per_side + util.round(pan_side * dots_per_side)
+    dots_right = util.round((1 - pan_side) * dots_per_side)
     if pan_side_percentage >= 1 then
-      descr = "R"..pan_side_percentage
+      descr = "R" .. pan_side_percentage
     end
   elseif value < 0 then
-    dots_left = util.round((1-pan_side)*dots_per_side)
-    dots_right = dots_per_side+util.round(pan_side*dots_per_side)
+    dots_left = util.round((1 - pan_side) * dots_per_side)
+    dots_right = dots_per_side + util.round(pan_side * dots_per_side)
     if pan_side_percentage >= 1 then
-     descr = "L"..pan_side_percentage
+      descr = "L" .. pan_side_percentage
     end
   else
     dots_left = dots_per_side
@@ -145,7 +155,7 @@ function Formatters.bipolar_as_pan_widget(param)
   add_dots(dots_right)
   add_bar()
 
-  return format(param, descr.." "..widget, "")
+  return format(param, descr .. " " .. widget, "")
 end
 
 --- unipolar_as_multimode_filter_freq
@@ -154,42 +164,46 @@ function Formatters.unipolar_as_multimode_filter_freq(param)
   local chars = 20
   local widget
   local function add_dots(num) -- TODO: refactor out
-    for i=1,num do widget = (widget or "").."." end
+    for i = 1, num do
+      widget = (widget or "") .. "."
+    end
   end
   local function add_bars(num) -- TODO: refactor out
-    for i=1,num do widget = (widget or "").."|" end
+    for i = 1, num do
+      widget = (widget or "") .. "|"
+    end
   end
 
   local value = ControlSpec.BIPOLAR:map(param:get())
   local abs_mapped_value = math.abs(value)
-  local percentage = util.round(abs_mapped_value*100)
+  local percentage = util.round(abs_mapped_value * 100)
   local descr
 
   if value > 0 then
-    local clear = value*chars
+    local clear = value * chars
     if percentage >= 1 then
-      descr = "HP"..percentage
+      descr = "HP" .. percentage
     end
     add_bars(1)
     add_dots(clear)
-    add_bars(chars-clear+1)
+    add_bars(chars - clear + 1)
   elseif value < 0 then
-    local fill = (value+1)*chars
+    local fill = (value + 1) * chars
     if percentage >= 1 then
-      descr = "LP"..(100-percentage)
+      descr = "LP" .. (100 - percentage)
     end
-    add_bars(fill+1)
-    add_dots(chars-fill)
+    add_bars(fill + 1)
+    add_dots(chars - fill)
     add_bars(1)
   else
-    add_bars(chars+2)
+    add_bars(chars + 2)
   end
 
   if descr == nil then
     descr = "OFF"
   end
 
-  return format(param, widget.." "..descr, "")
+  return format(param, widget .. " " .. descr, "")
 end
 
 --- round


### PR DESCRIPTION
(hihiiii! a lot of small tweaks among the large tweaks, will try to cover everything but please lmk if anything remains opaque!!)

this PR adds:
- UI for editing MIDI mapping
- `allow_pmap` flag
- MIDI echo back to mapped devices
- support binary-type parameters in UX/UI
- `examples/hello_pmaps.lua` to demonstrate!

## MIDI map UI

while in mapping mode, press ENTER on any mapped parameter to open the mapping for editing:
<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/73ffb356-98ce-4d92-a201-102f355f39cc">

here, you can manually modify:
- cc number
- channel number
- mapped device
- out: lowest parameter value (scales incoming CC value to this range)
- out: highest parameter value (scales incoming CC value to this range)
- in: lowest incoming value (any CC lower than this value will not affect the parameter)
- in: highest incoming value (any CC higher than this value will not affect the parameter)
- accum: enable when using relative / delta-based CC streams
- echo: enable to send the parameter's (scaled) value back to the mapped controller (for LED activity)

key nav:
- left/right: navigate mapping
- up/down: delta +/- 1
- right ALT + up/down: delta +/- 10
- TAB: cycle to next parameter
- SHIFT + TAB: cycle to previous parameter

## `allow_pmap` flag

by default, every action-based parameter (except text) is MIDI mappable. this can be changed via the `allow_pmap` flag, eg:

```lua
params:add {
    type = "number",
    id = "unmappable_number",
    name = "you cannot map this!",
    min = 0,
    max = 10,
    default = 0,
    allow_pmap = false,
  }
```

or
```lua
params:add_number('unmappable_number', 'you cannot map this!', 0, 10, 0, nil, false)
```

this flag prohibits mapping in both the map mode:

<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/2a0fca15-9b5f-42bf-9a61-be14d4782543">

and the mapping editor, if <kbd>TAB</kbd>'d over:

<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/8cd73ace-bab6-47fc-a43f-45c4f64058c0">

## MIDI echo

as part of the MIDI mapping editor, you can specify whether the parameter's current value should push back to the mapped device. this is useful for devices like the [MIDI Fighter Twister](https://store.djtechtools.com/products/midi-fighter-twister) which have CC-addressable LED's on each encoder. when a PMAP is loaded, any echo-enabled parameter will redraw to the mapped device.

## support binary-type parameters in UX/UI

previously, the binary parameter type wouldn't register in the UI and keypresses wouldn't register state changes. this has been addressed (w/ the same qt lil' squares as norns)!

<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/14cad758-0783-433a-96d0-f867753e984f">

## `hello_pmaps.lua`

it's in there!

<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/c7d0e386-d9b1-420d-b00c-2970cd2c787c">
