### PR TITLE
feat: add basic params "mouse-wheel" interaction

### DIFF
--- a/lua/core/menu/params-menu.lua
+++ b/lua/core/menu/params-menu.lua
@@ -57,6 +57,7 @@ local m = {
   ps_last = 0,
   dir_prev = nil,
   highlightColors = { r = 0, g = 140, b = 140 },
+  delta = 0,
 }
 
 local page
@@ -875,6 +876,19 @@ m.mouse = function(x, y) end
 
 m.click = function(x, y, state, button) end
 
-m.wheel = function (x, y)	end
+m.wheel = function (x, y)
+  if m.mode == mEDIT or m.mode == mMAP then
+    m.delta = m.delta + y
+    if m.delta >= 20 then
+      m.pos = util.clamp(m.pos + 1, 0, #page - 1)
+      m.delta = m.delta - 20
+      m.redraw()
+    elseif m.delta <= -20 then
+      m.pos = util.clamp(m.pos - 1, 0, #page - 1)
+      m.delta = m.delta + 20
+      m.redraw()
+    end
+  end
+end
 
 return m

--- a/lua/core/menu/params-menu.lua
+++ b/lua/core/menu/params-menu.lua
@@ -879,13 +879,13 @@ m.click = function(x, y, state, button) end
 m.wheel = function (x, y)
   if m.mode == mEDIT or m.mode == mMAP then
     m.delta = m.delta + y
-    if m.delta >= 20 then
+    if m.delta >= 5 then
       m.pos = util.clamp(m.pos + 1, 0, #page - 1)
-      m.delta = m.delta - 20
+      m.delta = m.delta % 5
       m.redraw()
-    elseif m.delta <= -20 then
+    elseif m.delta <= -5 then
       m.pos = util.clamp(m.pos - 1, 0, #page - 1)
-      m.delta = m.delta + 20
+      m.delta = m.delta % 5
       m.redraw()
     end
   end


### PR DESCRIPTION
with the new `screen.wheel` command, seamstress now responds to the mouse wheel.

i was trying to imagine a more achievable mouse + params interaction and figured that a "scrolling" motion (e.g. two-finger swipe up/down on a mac trackpad) to scroll through the params menu would be a good fit.

@dndrks would love thoughts if you have em, since you've done incredible work with building out the menu. (testing it out requires 0.23.0)