### PR TITLE
fix: triggers should reset instead of staying in "on" state

### DIFF
--- a/lua/core/params/binary.lua
+++ b/lua/core/params/binary.lua
@@ -44,6 +44,9 @@ function binary:set(v, silent)
       end
     end
   end
+  if self.behavior == "trigger" then
+    self.value = 0
+  end
 end
 
 function binary:delta(d)


### PR DESCRIPTION
before this PR, doing a `params:set("my_param", 1)` on a `trigger` param would have it stay "stuck" in this on state (like a `toggle`).

**NEED FOR REVIEW**: maybe should we do the **same thing for the `momentary` type**? idk what this type is and how it is supposed to behave.
