### PR TITLE
feat: add `-e` to run or list example scripts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -21,8 +21,14 @@ pub fn build(b: *std.Build) void {
         .install_dir = .{ .custom = "share/seamstress" },
         .install_subdir = "resources",
     });
+    const install_examples = b.addInstallDirectory(.{
+        .source_dir = .{ .path = "examples" },
+        .install_dir = .{ .custom = "share/seamstress" },
+        .install_subdir = "examples",
+    });
     b.getInstallStep().dependOn(&install_resources.step);
     b.getInstallStep().dependOn(&install_lua_files.step);
+    b.getInstallStep().dependOn(&install_examples.step);
 
     const zig_sdl = b.dependency("SDL", .{
         .target = target,

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -10,7 +10,7 @@ local luafiles = _pwd .. "/?.lua;"
 local seamstressfiles = seamstress_home .. "/?.lua;"
 
 --- custom package.path setting for require.
--- includes folders under `/usr/local/share/seamstress/lua`,
+-- includes folders under seamstress binary directory,
 -- as well as the current directory
 -- and `$HOME/seamstress`
 package.path = sys .. core .. lib .. luafiles .. seamstressfiles .. package.path

--- a/src/main.zig
+++ b/src/main.zig
@@ -29,10 +29,11 @@ var allocator: std.mem.Allocator = undefined;
 pub fn main() !void {
     var go_again = true;
     timer = try std.time.Timer.start();
-    const option = try args.parse();
 
     var loc_buf = [_]u8{0} ** std.fs.MAX_PATH_BYTES;
     const location = try std.fs.selfExeDirPath(&loc_buf);
+
+    const option = try args.parse(location);
 
     const logger = std.log.scoped(.main);
     logfile = try std.fs.createFileAbsolute("/tmp/seamstress.log", .{});


### PR DESCRIPTION
this PR adds a new CLI flag: `-e`.  when used as the last argument without a filename, seamstress prints the names of the example scripts it ships with and exits. when used with a filename, it does the following:
 - finds the matching script in the examples, 
 - attempts to copy (confirming for overwrite) the script from the examples into `~/seamstress`
 - loads the copied script with `-w`