### PR TITLE
FIX: add params menu UI flags to 'binary' params:set

### DIFF
--- a/lua/core/menu/params-menu.lua
+++ b/lua/core/menu/params-menu.lua
@@ -58,6 +58,8 @@ local m = {
   dir_prev = nil,
   highlightColors = { r = 0, g = 140, b = 140 },
   delta = 0,
+  triggered = {},
+  on = {},
 }
 
 local page

--- a/lua/core/params/binary.lua
+++ b/lua/core/params/binary.lua
@@ -34,11 +34,19 @@ function binary:get()
 end
 
 function binary:set(v, silent)
+  local lookup_id = params.lookup[self.id]
   silent = silent or false
   v = (v > 0) and 1 or 0
   if self.value ~= v then
     self.value = v
+    -- adjust params UI state:
+    if self.behavior ~= "trigger" then
+      paramsMenu.on[lookup_id] = self.value
+    else
+      paramsMenu.triggered[lookup_id] = 2
+    end
     if silent == false then
+      -- execute action:
       if self.behavior ~= "trigger" or v == 1 then
         self:bang()
       end


### PR DESCRIPTION
hihi! hope all's well :)

this PR adds UI flags to the `params:set()` action for `binary`-style parameters.

test script:

```lua
function init()
  params:add_binary("toggle", "toggle")
  params:set_action("toggle", function(x)
    print("toggle is " .. tostring(x == 1))
  end)
  params:add_binary("trigger", "trigger", "trigger")
  params:set_action("trigger", function()
    print("trigger is triggered")
  end)
  params:add_binary("momentary", "momentary", "momentary")
  params:set_action("momentary", function(x)
    print("momentary is " .. tostring(x == 1))
  end)
end
```

and execute (for example) `params:set('toggle', 1)` or `params:set('trigger', 1)` on the command line.
in the current build, this does not redraw the expected square in the params menu UI.
with this PR, the expected square state is drawn.

lmk if there's anything i missed / if there are any q's!