### PR TITLE
feat: add beat info to clock params UI

### DIFF
--- a/lua/core/menu/params-menu.lua
+++ b/lua/core/menu/params-menu.lua
@@ -298,6 +298,8 @@ m.key = function(char, modifiers, is_repeat, state)
       elseif state == 1 then
         if m.group == true then
           m.group = false
+          m.groupid = 0
+          m.groupname = nil
           build_page()
           m.pos = m.oldpos
         end
@@ -509,6 +511,22 @@ m.redraw = function()
     local n = "PARAMETERS"
     if m.group then
       n = n .. " / " .. m.groupname
+      if m.groupname == "CLOCK" then
+        screen.move(137,10)
+        local beatcount = math.floor(clock.get_beats()/0.25)*0.25
+        local is_whole = beatcount == math.floor(beatcount)
+        screen.color(255, 255, 255, is_whole and 255 or 130)
+        if params:get("clock_source") == 3 then
+          if _seamstress.transport_active then
+            screen.text("beat: "..beatcount)
+          else
+            screen.color(255, 255, 255, 130)
+            screen.text("waiting for Link start")
+          end
+        else
+          screen.text("beat: " .. beatcount)
+        end
+      end
     end
     screen.color(130, 140, 140, 255)
     screen.move(10, 10)


### PR DESCRIPTION
hihiii!

this PR adds some additional insights into current beat count, which i'm hoping can be helpful for making the often-on nature of the clock system a little more legible for general use.

## beat counter

in `PARAMETERS > CLOCK`, there's now a tracker for the current beat in the top right:
<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/8c1b873a-9530-4256-a1c5-8bccdb262a53">

it flashes white on every whole-beat, grey on every quarter.

## Link

when clock source is set to Link, seamstress will show the `quantum` parameter as well as whether it has received a transport start message from Link:

<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/b03bd7ee-5e15-47e2-b215-588b28d13984">

once a transport start message is received, the beats draw to the window:

<img width="1136" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/63b1d915-16c2-4842-b49a-c2da7ac3e0e8">

## other changes

### beat-synced paramsMenu redraw

the beat reporting + highlighting required a quarter-beat-synced `paramsMenu.redraw()` call, which is only enabled when the clock params menu is open.

### new var: `_seamstress.transport_active`

i added a new var: `_seamstress.transport_active`, which is set to `true` with `_seamstress.transport.start()` and false with `_seamstress.transport.stop()`. this allows the Link transport messaging, but seems like tracking this state could eventually be useful if you want to add more complex transport UI controls :)

### specify quantum is in 'beats'

just dropped in a string formatter after the `quantum` param :)

lmk if anything tests weird!