### PR TITLE
feat: clean up 'number' params instantiation

### DIFF
--- a/lua/core/params/control.lua
+++ b/lua/core/params/control.lua
@@ -128,9 +128,16 @@ function Control:bang()
 end
 
 --- get_range.
+-- @return range as table {minval, maxval}
 function Control:get_range()
   r = { self.controlspec.minval, self.controlspec.maxval }
   return r
+end
+
+--- get_wrap.
+-- @return wrap boolean
+function Control:get_wrap()
+  return self.controlspec.wrap
 end
 
 --- string.


### PR DESCRIPTION
hiiii!

this PR addresses the conditions which led to @sonocircuit's note in the norns study group:

> one thing that does not work on seamstress is returning the note value in the params instead of the number.
this works on norns: 
`params:add_number("root_note", "root note", 24, 84, 60, function(param) return mu.note_num_to_name(param:get(), true) end)`
but returns a concat error in seamstress

### new

- added a `type` check in `params:add_number` -- if `units` is a function, then we assume that is meant to be the `formatter` and we pass `nil` to our generated `controlspec`
- added a `wrap` argument to `params:add_number`, with a similar guardrail as above
- both of these assumptions print a heads-up to the console, eg.
  ```bash
    >> norns_style_wrap_root_note: 'units' was specified as a function, assuming 'formatter'.
       check seamstress scripting API for usage.
  ```
- added a `params:get_wrap(id)` action which allows querying the wrap state
- confirmed that `params:get_range(id)` returns a table of `{min, max}` in the API docs

### test script
```lua
local mu = require 'musicutil'

function init()
  params:add_number("norns_style-no_wrap_root_note", "root note", 24, 84, 60, function(param)
    return mu.note_num_to_name(param:get(), true)
  end)
  params:add_number("norns_style-wrap_root_note", "root note", 24, 84, 60, function(param)
    return mu.note_num_to_name(param:get(), true)
  end, true)
  params:add{
    type = "number",
    id = "wrap_root_note",
    name = "root note",
    min = 24,
    max = 84,
    default = 60,
    formatter = function(param)
      return mu.note_num_to_name(param:get(), true)
    end,
    wrap = true
  }
end
```

testing well over here, please lmk if there's anything wonky tho!!