### PR TITLE
feat: move small allocations to `FixedBufferAllocator`s

### DIFF
--- a/src/clock.zig
+++ b/src/clock.zig
@@ -5,6 +5,7 @@ const c = @cImport({
     @cInclude("abl_link.h");
 });
 
+var buf: [8 * 1024]u8 = undefined;
 var allocator: std.mem.Allocator = undefined;
 var fabric: *Fabric = undefined;
 var timer: std.time.Timer = undefined;
@@ -13,10 +14,11 @@ pub const Transport = enum { Start, Stop, Reset };
 pub const Source = enum(c_longlong) { Internal, MIDI, Link };
 const logger = std.log.scoped(.clock);
 
-pub fn init(time: std.time.Timer, alloc_pointer: std.mem.Allocator) !void {
+pub fn init(time: std.time.Timer) !void {
     quantum = 4.0;
     timer = time;
-    allocator = alloc_pointer;
+    var fba = std.heap.FixedBufferAllocator.init(&buf);
+    allocator = fba.allocator();
     fabric = try allocator.create(Fabric);
     fabric.link = c.abl_link_create(120);
     fabric.state = c.abl_link_create_session_state();

--- a/src/create.zig
+++ b/src/create.zig
@@ -2,12 +2,14 @@ const std = @import("std");
 const args = @import("args.zig");
 const c = @import("input.zig").c;
 
+var buf: [8 * 1024]u8 = undefined;
 var allocator: std.mem.Allocator = undefined;
 var location: []const u8 = undefined;
 var to_be_freed: ?[]const u8 = null;
 
-pub fn init(option: args.CreateOptions, alloc: std.mem.Allocator, loc: []const u8) !void {
-    allocator = alloc;
+pub fn init(option: args.CreateOptions, loc: []const u8) !void {
+    var fba = std.heap.FixedBufferAllocator.init(&buf);
+    allocator = fba.allocator();
     location = loc;
     _ = c.rl_initialize();
     c.rl_prep_terminal(1);

--- a/src/events.zig
+++ b/src/events.zig
@@ -14,12 +14,14 @@ pub const Data = union(enum) {
     Reset: void,
     Exec_Code_Line: struct {
         line: [:0]const u8,
+        allocator: std.mem.Allocator,
     },
     OSC: struct {
         from_host: [:0]const u8,
         from_port: [:0]const u8,
         path: [:0]const u8,
         msg: []osc.Lo_Arg,
+        allocator: std.mem.Allocator,
     },
     Monome_Add: struct {
         dev: *monome.Monome,
@@ -92,8 +94,8 @@ pub const Data = union(enum) {
     },
     MIDI: struct {
         id: u32,
-        msg_num: u64,
         message: []const u8,
+        allocator: std.mem.Allocator,
     },
     Clock_Resume: struct {
         id: u8,
@@ -119,16 +121,6 @@ fn prioritize(context: Context, a: Data, b: Data) std.math.Order {
                 else => return .lt,
             }
         },
-        .MIDI => |m| {
-            switch (b) {
-                .Clock_Resume, .Metro => return .gt,
-                .MIDI => |n| {
-                    if (m.id != n.id) return .eq;
-                    if (m.msg_num < n.msg_num) return .lt else return .gt;
-                },
-                else => return .eq,
-            }
-        },
         else => {
             switch (b) {
                 .Clock_Resume, .Metro => return .gt,
@@ -143,11 +135,13 @@ var queue: Queue = undefined;
 
 var quit = false;
 var reset = false;
+var gpa: std.heap.GeneralPurposeAllocator(.{}) = undefined;
 
-pub fn init(alloc_ptr: std.mem.Allocator) !void {
+pub fn init() !void {
     reset = false;
     quit = false;
-    allocator = alloc_ptr;
+    gpa = .{};
+    allocator = gpa.allocator();
     queue = Queue.init(allocator, .{ .cond = .{}, .lock = .{} });
     try queue.ensureTotalCapacity(5000);
 }
@@ -170,16 +164,16 @@ pub fn loop() !bool {
 pub fn free(event: Data) void {
     switch (event) {
         .OSC => |e| {
-            allocator.free(e.from_host);
-            allocator.free(e.from_port);
-            allocator.free(e.path);
-            allocator.free(e.msg);
+            e.allocator.free(e.from_host);
+            e.allocator.free(e.from_port);
+            e.allocator.free(e.path);
+            e.allocator.free(e.msg);
         },
         .Exec_Code_Line => |e| {
-            allocator.free(e.line);
+            e.allocator.free(e.line);
         },
         .MIDI => |e| {
-            allocator.free(e.message);
+            e.allocator.free(e.message);
         },
         else => {},
     }
@@ -211,6 +205,7 @@ pub fn handle_pending() !void {
 pub fn deinit() void {
     free_pending();
     queue.deinit();
+    _ = gpa.deinit();
 }
 
 fn free_pending() void {

--- a/src/link.zig
+++ b/src/link.zig
@@ -1,5 +1,0 @@
-const std = @import("std");
-const clock = @import("clock.zig");
-const c = @cImport({
-    @cInclude("abl_link.h");
-});

--- a/src/main.zig
+++ b/src/main.zig
@@ -149,7 +149,8 @@ fn inner(go_again: *bool) !void {
     try events.handle_pending();
 
     logger.info("spinning spindle", .{});
-    const filepath = try spindle.startup(args.script_file);
+    var buf: [1024]u8 = undefined;
+    const filepath = try spindle.startup(args.script_file, &buf);
 
     if (args.watch and filepath != null) {
         logger.info("watching {s}", .{filepath.?});

--- a/src/main.zig
+++ b/src/main.zig
@@ -39,16 +39,12 @@ pub fn main() !void {
     defer logfile.close();
     const logger = std.log.scoped(.app);
 
-    var general_allocator = std.heap.GeneralPurposeAllocator(.{}){};
-    var allocator = switch (comptime builtin.mode) {
-        .ReleaseFast => std.heap.raw_c_allocator,
-        else => general_allocator.allocator(),
-    };
-    defer _ = general_allocator.deinit();
-
-    if (option) |opt| try create.init(opt, allocator, location);
+    if (option) |opt| try create.init(opt, location);
     defer if (option) |_| create.deinit();
     while (go_again) {
+        var buf: [8 * 1024]u8 = undefined;
+        var fba = std.heap.FixedBufferAllocator.init(&buf);
+        var allocator = fba.allocator();
         if (!args.quiet) try print_version();
         const path = try std.fs.path.joinZ(allocator, &.{ location, "..", "share", "seamstress", "lua" });
         defer allocator.free(path);
@@ -63,35 +59,35 @@ pub fn main() !void {
         defer allocator.free(config);
 
         logger.info("init events", .{});
-        try events.init(allocator);
+        try events.init();
         defer events.deinit();
 
         logger.info("init metros", .{});
-        try metros.init(timer, allocator);
+        try metros.init(timer);
         defer metros.deinit();
 
         logger.info("init clocks", .{});
-        try clocks.init(timer, allocator);
+        try clocks.init(timer);
         defer clocks.deinit();
 
         logger.info("init spindle", .{});
-        try spindle.init(prefix, config, timer, allocator);
+        try spindle.init(prefix, config, timer);
 
         logger.info("init MIDI", .{});
-        try midi.init(allocator);
+        try midi.init();
         defer midi.deinit();
 
         logger.info("init osc", .{});
-        try osc.init(args.local_port, allocator);
+        try osc.init(args.local_port);
         defer osc.deinit();
 
         logger.info("init input", .{});
-        try input.init(allocator);
+        try input.init();
         defer input.deinit();
 
         logger.info("init socket", .{});
         const sock = try std.fmt.parseUnsigned(u16, args.socket_port, 10);
-        try socket.init(allocator, sock);
+        try socket.init(sock);
         defer socket.deinit();
 
         logger.info("init screen", .{});
@@ -101,10 +97,10 @@ pub fn main() !void {
         defer allocator.free(assets_path);
         var assets_buf = [_]u8{0} ** std.fs.MAX_PATH_BYTES;
         const assets = try std.fs.realpath(assets_path, &assets_buf);
-        try screen.init(allocator, width, height, assets);
+        try screen.init(width, height, assets);
         defer screen.deinit();
 
-        main_thread = try std.Thread.spawn(.{}, inner, .{ &go_again, try allocator.dupe(u8, location), allocator });
+        main_thread = try std.Thread.spawn(.{}, inner, .{&go_again});
         defer main_thread.join();
 
         screen.loop();
@@ -144,9 +140,8 @@ fn log(
     writer.print(prefix ++ "+{d}: " ++ format ++ "\n", .{timestamp} ++ log_args) catch return;
 }
 
-fn inner(go_again: *bool, location: []const u8, allocator: std.mem.Allocator) !void {
+fn inner(go_again: *bool) !void {
     main_thread.setName("seamstress_core") catch {};
-    defer allocator.free(location);
     const logger = std.log.scoped(.main);
     pthread.set_priority(99);
 
@@ -158,7 +153,7 @@ fn inner(go_again: *bool, location: []const u8, allocator: std.mem.Allocator) !v
 
     if (args.watch and filepath != null) {
         logger.info("watching {s}", .{filepath.?});
-        try watcher.init(allocator, filepath.?);
+        try watcher.init(filepath.?);
     }
 
     logger.info("entering main loop", .{});

--- a/src/metros.zig
+++ b/src/metros.zig
@@ -109,11 +109,13 @@ pub fn set_period(idx: u8, seconds: f64) void {
 
 const max_num_metros = 36;
 var metros: []Metro = undefined;
+var gpa: std.heap.GeneralPurposeAllocator(.{}) = undefined;
 var allocator: std.mem.Allocator = undefined;
 
-pub fn init(time: std.time.Timer, alloc_pointer: std.mem.Allocator) !void {
+pub fn init(time: std.time.Timer) !void {
     timer = time;
-    allocator = alloc_pointer;
+    gpa = .{};
+    allocator = gpa.allocator();
     metros = try allocator.alloc(Metro, max_num_metros);
     for (metros, 0..) |*metro, idx| {
         metro.* = .{ .id = @intCast(idx) };
@@ -121,6 +123,7 @@ pub fn init(time: std.time.Timer, alloc_pointer: std.mem.Allocator) !void {
 }
 
 pub fn deinit() void {
+    defer _ = gpa.deinit();
     defer allocator.free(metros);
     for (metros) |*metro| {
         if (metro.thread) |*pid| {

--- a/src/midi.zig
+++ b/src/midi.zig
@@ -24,8 +24,7 @@ pub const Device = struct {
 
     pub const Input = struct {
         ptr: *c.RtMidiWrapper,
-        buf: [8 * 1024]u8 = undefined,
-        allocator: std.mem.Allocator = undefined,
+        allocator: std.mem.Allocator = std.heap.raw_c_allocator,
 
         fn create(self: *Device, i: c_uint) !void {
             if (self.input) |_| return;
@@ -38,8 +37,6 @@ pub const Device = struct {
             self.input = .{
                 .ptr = midi_in,
             };
-            var fba = std.heap.FixedBufferAllocator.init(&self.input.?.buf);
-            self.input.?.allocator = fba.allocator();
             c.rtmidi_open_port(midi_in, i, name.ptr);
             c.rtmidi_in_set_callback(midi_in, read, self);
             c.rtmidi_in_ignore_types(midi_in, false, false, false);

--- a/src/monome.zig
+++ b/src/monome.zig
@@ -4,7 +4,8 @@ const c = osc.c;
 const events = @import("events.zig");
 
 var allocator: std.mem.Allocator = undefined;
-var devices: []Monome = undefined;
+var monomes: [8]Monome = undefined;
+var devices: []Monome = &monomes;
 const logger = std.log.scoped(.monome);
 
 pub const Monome_t = enum { Grid, Arc };
@@ -111,9 +112,8 @@ pub const Monome = struct {
     }
 };
 
-pub fn init(alloc_pointer: std.mem.Allocator, port: u16) !void {
-    allocator = alloc_pointer;
-    devices = try allocator.alloc(Monome, 8);
+pub fn init(alloc: std.mem.Allocator, port: u16) !void {
+    allocator = alloc;
     @memset(devices, .{});
     for (devices, 0..) |*device, i| {
         device.id = @intCast(i);
@@ -136,7 +136,6 @@ pub fn deinit() void {
         if (device.name) |n| allocator.free(n);
         c.lo_server_thread_free(device.thread);
     }
-    allocator.free(devices);
 }
 
 pub fn add(name: []const u8, dev_type: []const u8, port: i32) void {

--- a/src/screen.zig
+++ b/src/screen.zig
@@ -701,10 +701,9 @@ pub fn set_fullscreen_inner(is_fullscreen: bool) void {
     events.post(event);
 }
 
-pub fn init(alloc_pointer: std.mem.Allocator, width: u16, height: u16, resources: []const u8) !void {
+pub fn init(width: u16, height: u16, resources: []const u8) !void {
     quit = false;
-    allocator = alloc_pointer;
-
+    allocator = std.heap.raw_c_allocator;
     if (c.SDL_Init(c.SDL_INIT_VIDEO) < 0) {
         logger.err("screen.init(): {s}", .{c.SDL_GetError()});
         return error.Fail;

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const events = @import("events.zig");
 const logger = std.log.scoped(.watcher);
 
-var allocator: std.mem.Allocator = undefined;
 var thread: std.Thread = undefined;
 var quit = false;
 
@@ -11,9 +10,8 @@ pub fn deinit() void {
     thread.join();
 }
 
-pub fn init(alloc_pointer: std.mem.Allocator, path: [*:0]const u8) !void {
+pub fn init(path: [*:0]const u8) !void {
     quit = false;
-    allocator = alloc_pointer;
     thread = try std.Thread.spawn(.{}, loop, .{path});
 }
 


### PR DESCRIPTION
the purpose of this PR is to hopefully alleviate allocation churn in most cases. notably, this PR does not solve the sort of worrying growth of seamstress's resident size in `htop` when `hello_triangle` is run, which leads me to think that SDL is to blame here.

i'm going to leave this as a PR for a day or two, since it has the possibility to increase crashes, and i'd like to catch those myself if possible.