### PR TITLE
feat: add `screen.level` + `screen.update`

### DIFF
--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -28,6 +28,12 @@ function screen.refresh()
   _seamstress.screen_refresh()
 end
 
+--- norns alias to redraw the screen; reveal changes.
+-- @function screen.update
+function screen.update()
+  _seamstress.screen_refresh()
+end
+
 --- move the current position.
 -- @tparam integer x target x-coordinate (1-based)
 -- @tparam integer y target y-coordinate (1-based)
@@ -52,6 +58,13 @@ end
 -- @function screen.color
 function screen.color(r, g, b, a)
   _seamstress.screen_color(r, g, b, a or 255)
+end
+
+--- sets greyscale color/brightness.
+-- @tparam integer value (0-15; 0=off, 15=white)
+-- @function screen.level
+function screen.level(value)
+  _seamstress.screen_color(value * 17, value * 17, value * 17, 255)
 end
 
 --- draws a single pixel.


### PR DESCRIPTION
this PR adds a few bits for folks used to norns scripting:

- `screen.level` is a monochromatic level/color helper, which just draws varying levels of grayscale
- `screen.update` is an alias for `_seamstress.screen_refresh()`, which aligns with expectations of the norns `screen` module

i know there are a lot of other `screen` module changes, but i feel like these are good initial stumbling blocks which can help ease the introduction. please lmk if you have any additional thoughts or q's!!

```lua
function init()
  width = 128
  height = 64
  screen.set_size(width, height)
end

function redraw()
  screen.clear()
  for i = 0, 15 do
    screen.move(i * (width / 16)+1, height/3)
    screen.level(15 - i)
    screen.text(i)
    screen.move_rel(0,10)
    screen.level(i)
    screen.text(i)
  end
  screen.update()
end
```

<img width="624" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/44d88d23-c980-4b89-9fc5-58080870d27d">
