### PR TITLE
feat: add keyboard example

### DIFF
--- a/examples/hello_keyboard.lua
+++ b/examples/hello_keyboard.lua
@@ -4,6 +4,7 @@
 -- for a fully-developed script example, run 'seamstress -e plasma'
 
 function init()
+  screen.set_size(120,56)
   data = {
     modifier = "none",
     char = "none",

--- a/examples/hello_keyboard.lua
+++ b/examples/hello_keyboard.lua
@@ -4,13 +4,21 @@
 -- for a fully-developed script example, run 'seamstress -e plasma'
 
 function init()
-  screen.set_size(120,56)
+  screen.set_size(128,56)
   data = {
     modifier = "none",
     char = "none",
     is_repeat = "false",
     state = 0,
   }
+  display_lines = {
+    {"last char: ", "char"},
+    {"current mod: ", "modifier"},
+    {"repeat: ", "is_repeat"},
+    { "state: ", "state"}
+  }
+  L1 = 10
+  L2 = 15
 end
 
 function screen.key(char, modifiers, is_repeat, state)
@@ -32,14 +40,17 @@ end
 
 function redraw()
   screen.clear()
-  screen.level(15)
-  screen.move(10, 10)
-  screen.text("last char: " .. data.char)
-  screen.move_rel(0, 10)
-  screen.text("current mod: " .. data.modifier)
-  screen.move_rel(0, 10)
-  screen.text("repeat: " .. data.is_repeat)
-  screen.move_rel(0, 10)
-  screen.text("state: " .. data.state)
+  for i = 1,4 do
+    screen.move(10, 10 * i)
+    screen.level(L1)
+    local ln = display_lines[i][1] -- get text string
+    screen.text(ln) -- display text string
+    
+    local width,height = screen.get_text_size(ln)
+    screen.move_rel(width,0)
+    screen.level(L2)
+    ln = data[display_lines[i][2]] -- get data
+    screen.text(ln) -- display data
+  end
   screen.update()
 end

--- a/examples/hello_keyboard.lua
+++ b/examples/hello_keyboard.lua
@@ -1,0 +1,44 @@
+-- hello_keyboard.lua
+-- introduces how to capture and display keyboard input
+
+-- for a fully-developed script example, run 'seamstress -e plasma'
+
+function init()
+  data = {
+    modifier = "none",
+    char = "none",
+    is_repeat = "false",
+    state = 0,
+  }
+end
+
+function screen.key(char, modifiers, is_repeat, state)
+  if #modifiers == 1 then
+    data.modifier = modifiers[1]
+  elseif #modifiers == 0 then
+    data.modifier = "none"
+  end
+  if char.name ~= nil then
+    data.char = char.name
+  else
+    char = char == " " and "space" or char
+    data.char = char
+  end
+  data.is_repeat = tostring(is_repeat)
+  data.state = state
+  redraw()
+end
+
+function redraw()
+  screen.clear()
+  screen.level(15)
+  screen.move(10, 10)
+  screen.text("last char: " .. data.char)
+  screen.move_rel(0, 10)
+  screen.text("current mod: " .. data.modifier)
+  screen.move_rel(0, 10)
+  screen.text("repeat: " .. data.is_repeat)
+  screen.move_rel(0, 10)
+  screen.text("state: " .. data.state)
+  screen.update()
+end

--- a/examples/hello_keyboard.lua
+++ b/examples/hello_keyboard.lua
@@ -17,7 +17,7 @@ function init()
     {"repeat: ", "is_repeat"},
     { "state: ", "state"}
   }
-  L1 = 10
+  L1 = 7
   L2 = 15
 end
 


### PR DESCRIPTION
this PR adds a small example for capturing + displaying keyboard input, as `hello_keyboard.lua`:

<img width="624" alt="image" src="https://github.com/ryleelyman/seamstress/assets/24821020/57b9d764-f3c9-4193-9f19-dbc5a5429b0a">
