### PR TITLE
feat: semantic versioning check

### DIFF
--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -120,7 +120,9 @@ _startup = function(script_file)
       version_match = false
       goto finished
     elseif parsed_required_version[2] <= _seamstress.version[2] then
-      if parsed_required_version[3] > _seamstress.version[3] then
+      if parsed_required_version[3] == nil then
+        goto finished
+      elseif parsed_required_version[3] > _seamstress.version[3] then
         version_match = false
         goto finished
       end

--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -26,6 +26,7 @@ print = _seamstress.print
 seamstress = {}
 
 seamstress.state = require("core/state")
+seamstress.version_required = nil
 
 _menu.timer = metro[36]
 

--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -104,7 +104,40 @@ _startup = function(script_file)
   end
 
   clock.add_params()
-  init()
+  local version_match = true
+  if seamstress.version_required ~= nil then
+    local parsed_required_version = {}
+    for str in string.gmatch(seamstress.version_required, "([^.]+)") do
+      table.insert(parsed_required_version, tonumber(str))
+    end
+    if parsed_required_version[1] > _seamstress.version[1] then
+      version_match = false
+      goto finished
+    elseif parsed_required_version[1] < _seamstress.version[1] then
+      goto finished
+    end
+    if parsed_required_version[2] > _seamstress.version[2] then
+      version_match = false
+      goto finished
+    elseif parsed_required_version[2] <= _seamstress.version[2] then
+      if parsed_required_version[3] > _seamstress.version[3] then
+        version_match = false
+        goto finished
+      end
+    end
+  end
+  ::finished::
+  if version_match then
+    init()
+  else
+    print(
+      "!!! this script ("
+        .. seamstress.state.name
+        .. ") requires seamstress version "
+        .. seamstress.version_required
+    )
+    print("!!! script not initialized, please update seamstress")
+  end
   paramsMenu.init()
   pmap.read()
   if seamstress.state.path then


### PR DESCRIPTION
this PR adds a check for a `seamstress.version_required` string outside of a script's `init` function, to determine if the installed instance of seamstress matches the requirements of the script. if this check fails, the script `init()` is not executed and an error is printed to the REPL.

**test script**
```lua
seamstress.version_required = "1.0.7" -- replace with different semantic version strings

function init()
  print("script loaded!")
end
```

## testing with 1.0.5
### failed
`seamstress.version_required = "1.0.7"` fails with:
```
seamstress version: 1.0.5
!!! this script (<scriptname>) requires seamstress version 1.0.7
!!! script not initialized, please update seamstress
```
`seamstress.version_required = "2.0.5"` fails with:
```
seamstress version: 1.0.5
!!! this script (<scriptname>) requires seamstress version 2.0.5
!!! script not initialized, please update seamstress
```
`seamstress.version_required = "1.1"` fails with:
```
seamstress version: 1.0.5
!!! this script (<scriptname>) requires seamstress version 1.1
!!! script not initialized, please update seamstress
```
### passed
- `seamstress.version_required = "1.0"`
- `seamstress.version_required = "0.0.7"`
- `seamstress.version_required = "0.9.3"`
- `seamstress.version_required = "1.0.5"`