### PR TITLE
alias `clock.get_beat_sec` to `clock.get_sec_per_beat`

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -107,6 +107,12 @@ function clock.get_sec_per_beat()
   return 60 / bpm
 end
 
+--- alias to get_sec_per_beat, for norns compatibility
+-- @treturn number seconds
+function clock.get_beat_sec()
+  return clock.get_sec_per_beat()
+end
+
 --- sets the clock source
 -- @tparam string source "internal" or "midi"
 clock.set_source = function(source)


### PR DESCRIPTION
`clock.get_sec_per_beat` is called `clock.get_beat_sec` in norns.

having an alias, akin to `screen.refresh`/ `screen.update`, allows for easier porting of norns scripts & libs.

this one is notably useful for [nb](https://github.com/sixolet/nb/blob/main/lib/player.lua#L118).