### PR TITLE
fix arc led index wrap

### DIFF
--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -87,7 +87,7 @@ function Arc.remove(dev) end
 -- @tparam integer val level (0-15)
 -- @function arc:led
 function Arc:led(ring, x, val)
-  _seamstress.arc_set_led(self.dev, ring, util.wrap(x, 1, 64), val)
+  _seamstress.arc_set_led(self.dev, ring, x, val)
 end
 
 --- set all leds.

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -87,7 +87,7 @@ function Arc.remove(dev) end
 -- @tparam integer val level (0-15)
 -- @function arc:led
 function Arc:led(ring, x, val)
-  _seamstress.arc_set_led(self.dev, ring, x, val)
+  _seamstress.arc_set_led(self.dev, ring, util.wrap(x, 1, 64), val)
 end
 
 --- set all leds.

--- a/src/spindle.zig
+++ b/src/spindle.zig
@@ -403,9 +403,10 @@ fn arc_set_led(l: *Lua) i32 {
     l.checkType(1, ziglua.LuaType.light_userdata);
     const md = l.toUserdata(monome.Monome, 1) catch unreachable;
     const ring: u8 = @intFromFloat(l.checkNumber(2) - 1);
-    const led: u8 = @intFromFloat(l.checkNumber(3) - 1);
+    const led: i32 = @intFromFloat(l.checkNumber(3) - 1);
+    const u8_led: u8 = @mod(led, 64);
     const val: u8 = @intFromFloat(l.checkNumber(4));
-    md.arc_set_led(ring, led, val);
+    md.arc_set_led(ring, u8_led, val);
     l.setTop(0);
     return 0;
 }


### PR DESCRIPTION
before this change:
- `a:led(1, 64+1, 10)` would light led `#1` on ring `#2`
- `a:led(1, 0, 10)` would crash seamstress

this PR implements wrapping of the led index (modulo 64, 1-indexed), akin to what norns does.

to test:

```lua

-- ------------------------------------------------------------------------
-- state

local a = nil

radial_pos = 1


-- ------------------------------------------------------------------------
-- init

local arc_redraw_clock
local ARC_FPS = 60

function init()
  a = arc.connect()

  arc_redraw_clock = clock.run(
    function()
      local step_s = 1 / ARC_FPS
      while true do
        clock.sleep(step_s)
        arc_redraw()
      end
  end)
end


-- ------------------------------------------------------------------------
-- main

function arc_redraw()

  -- spills over next ring after 64
  radial_pos = radial_pos + 1

  -- crashes
  -- radial_pos = radial_pos - 1

  a:all(0)

  a:led(1, radial_pos, 10)

  a:refresh()
end
``` 