### PR TITLE
expose `version_compare`, simpler implem, leaner startup code

### DIFF
--- a/lua/core/seamstress.lua
+++ b/lua/core/seamstress.lua
@@ -105,31 +105,7 @@ _startup = function(script_file)
   end
 
   clock.add_params()
-  local version_match = true
-  if seamstress.version_required ~= nil then
-    local parsed_required_version = {}
-    for str in string.gmatch(seamstress.version_required, "([^.]+)") do
-      table.insert(parsed_required_version, tonumber(str))
-    end
-    if parsed_required_version[1] > _seamstress.version[1] then
-      version_match = false
-      goto finished
-    elseif parsed_required_version[1] < _seamstress.version[1] then
-      goto finished
-    end
-    if parsed_required_version[2] > _seamstress.version[2] then
-      version_match = false
-      goto finished
-    elseif parsed_required_version[2] <= _seamstress.version[2] then
-      if parsed_required_version[3] == nil then
-        goto finished
-      elseif parsed_required_version[3] > _seamstress.version[3] then
-        version_match = false
-        goto finished
-      end
-    end
-  end
-  ::finished::
+  local version_match = (seamstress.version_required == nil) or util.version_compare(seamstress.version_required, _seamstress.version) <= 0
   if version_match then
     init()
   else

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -292,4 +292,41 @@ function util.wrap_max(n, min, max)
   return util.wrap(n, min, max)
 end
 
+--- parse a version string into a list of ints
+-- @tparam string v
+-- @treturn table
+function util.version_parse(v)
+  local parsed = {}
+  for str in string.gmatch(v, "([^.]+)") do
+    table.insert(parsed, tonumber(str))
+  end
+  return parsed
+end
+
+--- compare versions v1 and v2
+-- @tparam string v1
+-- @tparam string v2
+-- @treturn integer
+function util.version_compare(v1, v2)
+  if type(v1) == "string" then
+    v1 = util.version_parse(v1)
+  end
+  if type(v2) == "string" then
+    v2 = util.version_parse(v2)
+  end
+
+  if #v1 ~= #v2 then
+    return nil
+  end
+
+  for i=1,#v1 do
+    if v1[i] ~= v2[i] then
+      return (v1[i] > v2[i]) and 1 or -1
+    end
+  end
+
+  return 0
+end
+
+
 return util


### PR DESCRIPTION
having a `util.compare_version` fn could be handy for other contexts.

more importantly, having it in a lib makes the startup script leanr and easier to read.

i also optimized the implem & made it support any number of version elements.