### PR TITLE
fix high CPU usage due to ableton link threads

### DIFF
--- a/src/clock.zig
+++ b/src/clock.zig
@@ -189,6 +189,8 @@ const Link_Beat_Reference = struct {
     fn loop(self: *@This()) void {
         self.thread.setName("link_clock_thread") catch {};
         while (!self.quit) {
+            std.time.sleep(std.time.ns_per_s);
+
             c.abl_link_capture_audio_session_state(fabric.link, fabric.state);
             self.lock.lock();
             self.beat.last_beat_time = timer.read();

--- a/src/clock.zig
+++ b/src/clock.zig
@@ -125,7 +125,7 @@ const Fabric = struct {
             self.lock.lock();
             self.do_tick();
             self.lock.unlock();
-            std.time.sleep(1000);
+            std.time.sleep(std.time.ns_per_us * 100);
         }
     }
     fn do_tick(self: *Fabric) void {
@@ -189,8 +189,6 @@ const Link_Beat_Reference = struct {
     fn loop(self: *@This()) void {
         self.thread.setName("link_clock_thread") catch {};
         while (!self.quit) {
-            std.time.sleep(std.time.ns_per_s);
-
             c.abl_link_capture_audio_session_state(fabric.link, fabric.state);
             self.lock.lock();
             self.beat.last_beat_time = timer.read();
@@ -211,7 +209,7 @@ const Link_Beat_Reference = struct {
             }
             if (last > beat) reschedule_sync_events();
             c.abl_link_commit_audio_session_state(fabric.link, fabric.state);
-            std.time.sleep(1000);
+            std.time.sleep(std.time.ns_per_us * 100);
         }
     }
 };


### PR DESCRIPTION
**identifying the source of high CPU usage**

i used `Instruments.app` from XCode. you just have to launch it and filter on the "seamstress" process name.

we get:

![image](https://github.com/ryleelyman/seamstress/assets/11557146/a742c081-a6fb-4293-bdc7-684c178379d3)

from a 30s run, we can see that 2 threads are responsible for the most of the CPU time, both linked to ableton link (`clock.Link_Beat_Reference.loop` and `clock.Fabric.loop`).

the other loops take way less CPU time in comparison.

**the "fix"**

my fix certainly isn't *right* or the best way to proceed.

adding a sleep at the begining of the `clock.Link_Beat_Reference.loop` seem to drastically reduce the CPU usage by half. ableton link seem to still continue working.

doing the same thing to `clock.Fabric.loop` seems to make seamstress very laggy.

so there are more stuff to explore but the issue is around those 2 threads.