### PR TITLE
Ensure mapping px to tab indices range can match all available tab indices

### DIFF
--- a/lua/lib/ui.lua
+++ b/lua/lib/ui.lua
@@ -169,7 +169,7 @@ function UI.Tabs:click(x, y, state, button)
   if x < MARGIN or x > WIDTH - MARGIN then
     return
   end
-  local idx = util.linlin(MARGIN, WIDTH - MARGIN, 1, #self.titles, x)
+  local idx = util.linlin(MARGIN, WIDTH - MARGIN, 1, #self.titles + 1, x)
   self:set_index(math.floor(idx))
 end
 


### PR DESCRIPTION
Flooring the raw indices on line 173 was causing issues where the last title of a UI tabs object could never be successfully clicked on. Another solution would be to round the index instead of flooring it. 