### PR TITLE
feat!: timers, rework update / draw cycle

### DIFF
--- a/lua/seamstress/definitions/seamstress/async.lua
+++ b/lua/seamstress/definitions/seamstress/async.lua
@@ -1,0 +1,66 @@
+---@meta
+
+---@module 'seamstress.async'
+
+---creates an asynchronous function
+---@class seamstress.async
+---@overload fun(f: fun(...): any?): (fun(...): Promise)
+seamstress.async = {}
+
+---@class Promise
+---@overload fun(f: fun(...): any?): Promise
+local Promise = {}
+
+seamstress.async.Promise = Promise
+
+---must be called from an async context (e.g. a Promise or a coroutine)
+---the following code snippets are equivalent; both will print "the number is 25".
+---```lua
+---local a = seamstress.async(function(x) return x + 12 end)
+---local b = seamstress.async.Promise(function()
+---  a(13):anon(function(x) print('the number is ' .. x) end)
+---end)
+---local c = seamstress.async.Promise(function()
+---  local x = a(13):await()
+---  print('the number is ' .. x)
+---end)
+---```
+---@return any? # the return values of the Promise's function, or an error if the Promise was rejected
+function Promise:await() end
+
+---registers functions to be called when the Promise is settled
+---the name is chosen for expressions like "I shall return anon":
+---in JavaScript the same functionality is provided by a function named "then",
+---which is a reserved word in Lua.
+---Values (or errors) returned by the Promise's body are passed as arguments
+---to the appropriate function.
+---@param resolve fun(...): any? called if self is fulfilled
+---@param reject fun(err: string, ...): any? called if self is rejected
+---@return Promise a new promise which is fulfilled upon sucessful completion of either handler
+function Promise:anon(resolve, reject) end
+
+---equivalent to Promise:anon(function(...) return ... end, reject)
+---@param reject fun(err: string, ...): any? called if self is rejected
+function Promise:catch(reject) end
+
+---equivalent to Promise:anon(anyhow, anyhow)
+---@param anyhow fun(...): any? called when self is settled
+function Promise:finally(anyhow) end
+
+---creates a new Promise which fulfills when all of its arguments fulfill.
+---the Promise rejects if any of its arguments reject.
+---@param ... Promise[]
+---@return Promise
+function Promise.all(...) end
+
+---creates a new Promise which fulfills when any of its arguments fulfill.
+---the Promise rejects if all of its arguments reject.
+---@param ... Promise[]
+---@return Promise
+function Promise.any(...) end
+
+---creates a new Promise which settles when any of its arguments settle.
+---@param ... Promise[]
+---@return Promise
+function Promise.race(...) end
+

--- a/lua/seamstress/definitions/seamstress/timer.lua
+++ b/lua/seamstress/definitions/seamstress/timer.lua
@@ -1,0 +1,20 @@
+---@meta
+
+---@module 'seamstress.Timer'
+
+---@class Timer
+---@field action fun(self: Timer, dt: number)
+---@field delta number # must be positive
+---@field stage_end integer # negative means infinite
+---@field stage integer # current stage
+---@field running boolean # set false to stop, true to start
+local Timer = {}
+
+---creates a new Timer
+---@param action fun(self: Timer, dt: number)
+---@param delta number # must be positive
+---@param stage_end integer? # negative means infinite
+---@param stage integer? # defaults to 1
+---@param running boolean? # defaults to true; set running state
+---@return Timer
+seamstress.Timer = function(action, delta, stage_end, stage, running) end

--- a/lua/seamstress/definitions/seamstress/tui.lua
+++ b/lua/seamstress/definitions/seamstress/tui.lua
@@ -1,6 +1,7 @@
 ---@meta
 ---@module 'seamstress.tui'
 
+---@class seamstress.tui
 seamstress.tui = require'seamstress.tui'
 
 ---creates a Line or Lines from text
@@ -18,7 +19,7 @@ function Line:width() end
 
 ---like string:sub but for Line objects
 ---@param start integer
----@param finish? integer|-1
+---@param finish integer # defaults to -1, i.e. "the end"
 ---@return Line
 function Line:sub(start, finish) end
 
@@ -91,3 +92,12 @@ function seamstress.tui.showCursorInBox(x, y, box) end
 ---clears the box
 ---@param box Box
 function seamstress.tui.clearBox(box) end
+
+---toggles whether seamstress is in the terminal "alt screen"
+---@param alt_screen boolean
+function seamstress.tui.setAltScreen(alt_screen) end
+
+---tells seamstress to actually update the screen
+---by default, automatically called at the end of a "draw" event
+---unless a handler cancels the render by returning `false`
+function seamstress.tui.renderCommit() end

--- a/lua/seamstress/seamstress.lua
+++ b/lua/seamstress/seamstress.lua
@@ -97,6 +97,23 @@ else
   modules.tui = false
 end
 
+-- add with lowest priority so that we commit the render at the end
+seamstress.event.addSubscriber({ 'draw' }, function()
+  if seamstress.tui then seamstress.tui.renderCommit() end
+  return true
+end, { priority = 0 })
+
+-- NB: starts disabled! enable with seamstress.update.running = true
+seamstress.update = seamstress.Timer(function(_, dt)
+  local ret = seamstress.event.publish({ 'update' }, dt)
+  for _, v in ipairs(ret) do
+    if v then
+      seamstress.event.publish({ 'draw' })
+      break
+    end
+  end
+end, 1 / 60, -1, 1, false)
+
 ---startup function
 seamstress._start = function()
   local filename = seamstress.config.script_name

--- a/lua/seamstress/test/init.lua
+++ b/lua/seamstress/test/init.lua
@@ -2,10 +2,11 @@ local tests = {
   run = function()
     local ok, runner = pcall(require, 'busted.runner')
     if ok then
-      test_runner = seamstress.async.Promise(function()
+      seamstress.async.Promise(function()
          runner({ output = seamstress._prefix .. '/seamstress/test/seamstress_output.lua'})
         if seamstress.tui then require('seamstress.test.tui') end
-        require('seamstress.test.async')
+         require('seamstress.test.async')
+         require('seamstress.test.timer')
         os.exit = seamstress.quit
       end)
       return

--- a/lua/seamstress/test/timer.lua
+++ b/lua/seamstress/test/timer.lua
@@ -1,0 +1,29 @@
+local busted = require 'busted'
+
+busted.describe('seamstress.Timer', function()
+  busted.it('wait one second', function()
+    local done = false
+    local del = 0
+    local t = seamstress.Timer(function(self, dt)
+      del = dt
+      busted.assert.same(1, self.stage)
+      done = true
+    end, 1, 1)
+    busted.assert.same(true, t.running)
+    repeat coroutine.yield() until done
+    busted.assert(del > 0)
+  end)
+  busted.it('number go up', function()
+    local done = 0
+    local t = seamstress.Timer(function(self) done = self.stage end, 0.001, 5)
+    repeat coroutine.yield() until done >= 5
+    busted.assert.same(false, t.running)
+  end)
+  busted.it('can start dead', function()
+    local done = false
+    local t = seamstress.Timer(function() done = true end, 0.001, nil, nil, false)
+    busted.assert.same(false, t.running)
+    t.running = true
+    repeat coroutine.yield() until done
+  end)
+end)

--- a/src/lua_util.zig
+++ b/src/lua_util.zig
@@ -204,14 +204,6 @@ pub fn luaPrint(l: *Lua) void {
     l.call(n, 0);
 }
 
-/// renders to the terminal
-pub fn render(l: *Lua) void {
-    const wheel = getWheel(l);
-    if (wheel.render) |r| {
-        r.render_fn(r.ctx, wheel, wheel.timer.lap());
-    }
-}
-
 /// checks whether the given argument is callable, raises a type error if not
 /// if so, pushes the relevant function onto the stack
 pub fn checkCallable(l: *Lua, arg: i32) void {
@@ -230,4 +222,20 @@ pub fn checkCallable(l: *Lua, arg: i32) void {
         else => {},
     }
     l.typeError(arg, "callable value");
+}
+
+/// checks whether any elements of the table on top of the stack are truthy
+/// does not pop the table
+pub fn anyTruthy(l: *Lua) bool {
+    l.len(-1);
+    const len = l.toInteger(-1) catch unreachable;
+    l.pop(1);
+    var i: ziglua.Integer = 1;
+    while (i <= len) : (i += 1) {
+        _ = l.getIndex(-1, i);
+        const truthy = l.toBoolean(-1);
+        l.pop(1);
+        if (truthy) break;
+    } else return false;
+    return true;
 }

--- a/src/modules/cli.zig
+++ b/src/modules/cli.zig
@@ -10,19 +10,6 @@ c_c: xev.Completion = .{},
 continuing: bool = false,
 dirty: bool = false,
 
-/// flushes stdout and stderr, and re-prompts (usually)
-fn render(ctx: *anyopaque, _: *Wheel, _: u64) void {
-    const self: *Cli = @ptrCast(@alignCast(ctx));
-    if (!self.dirty) return;
-    self.dirty = false;
-    const writer = self.stdout.writer();
-    if (self.continuing)
-        writer.writeAll(">... ") catch panic("unable to print!", .{})
-    else
-        writer.writeAll("> ") catch panic("unable to print!", .{});
-    self.stdout.flush() catch panic("unable to print!", .{});
-}
-
 /// processes a chunk of stdin, renders, rinses and repeats
 fn handleStdin(
     self: ?*Cli,
@@ -132,10 +119,6 @@ fn launch(m: *const Module, _: *Lua, wheel: *Wheel) anyerror!void {
     const self: *Cli = @ptrCast(@alignCast(m.self.?));
     try self.stdin_buf.ensureUnusedCapacity(4096);
     const slice = self.stdin_buf.unusedCapacitySlice();
-    wheel.render = .{
-        .ctx = self,
-        .render_fn = render,
-    };
     self.file.read(&wheel.loop, &self.c, .{ .slice = slice[0..@min(slice.len, 4096)] }, Cli, self, handleStdin);
 }
 

--- a/src/spindle.zig
+++ b/src/spindle.zig
@@ -106,6 +106,7 @@ fn setUpSeamstress(l: *Lua, seamstress: *Seamstress, script: ?[:0]const u8) !voi
         l.setField(-2, "script_name");
         l.setField(-2, "config");
         l.setGlobal("seamstress");
+        try @import("timer.zig").registerSeamstress(l);
         defer a.free(seamstress_lua);
         try l.doFile(seamstress_lua);
     }
@@ -134,7 +135,7 @@ fn setUpSeamstress(l: *Lua, seamstress: *Seamstress, script: ?[:0]const u8) !voi
         l.setField(-2, "version");
     }
     l.pop(1);
-    try Promise.registerSeamstress(l);
+    try @import("async.zig").registerSeamstress(l);
 }
 
 /// starts the lua VM and sets up the seamstress table
@@ -167,7 +168,6 @@ fn luaPanic(l: *Lua) i32 {
 const ziglua = @import("ziglua");
 const Lua = ziglua.Lua;
 const Seamstress = @import("seamstress.zig");
-const Promise = @import("async.zig");
 const std = @import("std");
 const panic = std.debug.panic;
 const lu = @import("lua_util.zig");

--- a/src/timer.zig
+++ b/src/timer.zig
@@ -1,0 +1,232 @@
+/// Lua-owned libxev timers.
+pub fn registerSeamstress(l: *Lua) !void {
+    try l.newMetatable("seamstress.Timer");
+    _ = l.pushStringZ("__index");
+    l.pushFunction(ziglua.wrap(index));
+    l.setTable(-3);
+    _ = l.pushStringZ("__newindex");
+    l.pushFunction(ziglua.wrap(newindex));
+    l.setTable(-3);
+    _ = l.pushStringZ("__gc");
+    l.pushFunction(ziglua.wrap(gc));
+    l.setTable(-3);
+    l.pop(1);
+    lu.getSeamstress(l);
+    _ = l.pushStringZ("Timer");
+    l.pushFunction(ziglua.wrap(new));
+    l.setTable(-3);
+    l.pop(1);
+}
+
+fn new(l: *Lua) i32 {
+    const delta = l.optNumber(2) orelse 1;
+    l.argCheck(delta >= std.math.floatEps(f64), 2, "delta must be positive");
+    const stage_end = l.optNumber(3) orelse -1;
+    const stage = l.optNumber(4) orelse 1;
+    const t = l.newUserdata(xev.Timer, 8);
+    _ = l.getMetatableRegistry("seamstress.Timer");
+    l.setMetatable(-2);
+    lu.checkCallable(l, 1);
+    t.* = xev.Timer.init() catch |err| l.raiseErrorStr("error creating new timer! %s", .{@errorName(err)});
+    l.setUserValue(-2, 1) catch unreachable; // function: 1
+    l.newTable();
+    l.setUserValue(-2, 8) catch unreachable; // data: 8
+    l.pushNumber(delta);
+    l.setUserValue(-2, 2) catch unreachable; // delta (in seconds): 2
+    l.pushNumber(stage_end);
+    l.setUserValue(-2, 3) catch unreachable; // stage_end: 3
+    l.pushNumber(stage);
+    l.setUserValue(-2, 4) catch unreachable; // stage: 4
+    const t5 = l.typeOf(5);
+    const running = t5 == .none or t5 == .nil or l.toBoolean(5);
+    l.pushBoolean(running);
+    l.setUserValue(-2, 5) catch unreachable; // running: 5
+    const wheel = lu.getWheel(l);
+    const now = wheel.timer.read();
+    l.pushInteger(@bitCast(now));
+    l.setUserValue(-2, 6) catch unreachable; // current time (in ns): 6
+    const c = l.newUserdata(xev.Completion, 0);
+    c.* = .{};
+    l.setUserValue(-2, 7) catch unreachable; // completion: 7
+    if (!running) return 1;
+    l.pushValue(-1);
+    const next: u64 = @intFromFloat(delta * std.time.ms_per_s);
+    const handle = l.ref(ziglua.registry_index) catch l.raiseErrorStr("unable to register timer!", .{});
+    t.run(&wheel.loop, c, next, anyopaque, @ptrFromInt(@as(u32, @bitCast(handle))), bang);
+    return 1;
+}
+
+fn bang(ud: ?*anyopaque, loop: *xev.Loop, c: *xev.Completion, r: xev.Timer.RunError!void) xev.CallbackAction {
+    const handle: i32 = @bitCast(@as(u32, @intCast(@intFromPtr(ud))));
+    _ = r catch |err| panic("timer error: {s}", .{@errorName(err)});
+    const l = Wheel.getLua(loop);
+    const top = l.getTop();
+    defer std.debug.assert(top == l.getTop());
+    _ = l.rawGetIndex(ziglua.registry_index, handle); // push Timer userdata
+    const self = l.toUserdata(xev.Timer, -1) catch unreachable;
+    var rearm = true;
+    defer if (!rearm) l.unref(ziglua.registry_index, handle); // discard timer when not on event loop
+    _ = l.getUserValue(-1, 3) catch unreachable; // stage_end: 3
+    const stage_end = l.toNumber(-1) catch unreachable;
+    _ = l.getUserValue(-2, 4) catch unreachable; // stage: 4
+    const stage = l.toNumber(-1) catch unreachable;
+    l.pop(2);
+    if (stage_end >= std.math.floatEps(f64) and stage - 1 >= stage_end) {
+        rearm = false;
+        l.pushBoolean(false);
+        l.setUserValue(-2, 5) catch unreachable; // running: 5
+        l.pop(1);
+        return .disarm;
+    }
+    _ = l.getUserValue(-1, 5) catch unreachable; // running: 5
+    const running = l.toBoolean(-1);
+    l.pop(1);
+    if (!running) {
+        rearm = false;
+        l.pop(1);
+        return .disarm;
+    }
+
+    const wheel: *Wheel = @fieldParentPtr("loop", loop);
+    const now = wheel.timer.read(); // get current time
+    _ = l.getUserValue(-1, 6) catch unreachable; // current time (in ns): 6
+    const then: u64 = @bitCast(l.toInteger(-1) catch unreachable);
+    _ = l.getUserValue(-2, 2) catch unreachable; // delta: 2
+    const old_delta = l.toNumber(-1) catch unreachable;
+    const old_delta_ms: u64 = @intFromFloat(old_delta * std.time.ms_per_s);
+    l.pop(2);
+
+    l.pushInteger(@bitCast(now));
+    l.setUserValue(-2, 6) catch unreachable; // current time (in ns): 6
+    const dt: f64 = @as(f64, @floatFromInt(now - then)) / std.time.ns_per_s;
+    logger.debug("{d}", .{dt});
+    _ = l.getUserValue(-1, 1) catch unreachable; // function
+    l.pushValue(-2); // self
+    l.pushNumber(dt); // dt
+    lu.doCall(l, 2, 0); // call function
+
+    _ = l.getUserValue(-1, 4) catch unreachable; // stage: 4
+    const new_stage = (l.toNumber(-1) catch unreachable) + 1;
+    l.pop(1);
+    l.pushNumber(new_stage); // stage = stage + 1
+    l.setUserValue(-2, 4) catch unreachable;
+    _ = l.getUserValue(-1, 5) catch unreachable; // running: 5
+    const new_running = l.toBoolean(-1);
+    l.pop(1);
+    if (!new_running) {
+        rearm = false;
+        l.pop(1);
+        return .disarm;
+    }
+    _ = l.getUserValue(-1, 2) catch unreachable; // delta: 2
+    const delta = l.toNumber(-1) catch unreachable;
+    const delta_ms: u64 = @intFromFloat(delta * std.time.ms_per_s);
+    const next = (then + old_delta_ms + delta_ms) -| now; // keep time with our intentions
+    l.pop(2);
+    self.run(loop, c, next, anyopaque, ud, bang);
+    return .disarm;
+}
+
+fn gc(l: *Lua) i32 {
+    const timer = l.checkUserdata(xev.Timer, 1, "seamstress.Timer");
+    timer.deinit();
+    return 0;
+}
+
+fn index(l: *Lua) i32 {
+    const t = l.typeOf(2);
+    if (t == .string) {
+        const str = l.toString(2) catch unreachable;
+        inline for (indices) |tuple| {
+            if (std.mem.eql(u8, str, tuple[0])) {
+                _ = l.getUserValue(1, tuple[1]) catch unreachable;
+                return 1;
+            }
+        }
+    }
+    _ = l.getUserValue(1, 8) catch unreachable;
+    _ = l.pushValue(2);
+    _ = l.getTable(-2);
+    l.remove(-2);
+    return 1;
+}
+
+fn newindex(l: *Lua) i32 {
+    const t = l.typeOf(2);
+    if (t == .string) {
+        const key = l.toString(2) catch unreachable;
+        if (std.mem.eql(u8, "delta", key)) {
+            const delta = l.checkNumber(3);
+            l.argCheck(delta >= std.math.floatEps(f64), 3, "delta must be positive");
+            l.pushNumber(delta);
+            l.setUserValue(1, 2) catch unreachable;
+            return 0;
+        }
+        if (std.mem.eql(u8, "running", key)) {
+            const running = l.toBoolean(3);
+            _ = l.getUserValue(1, 5) catch unreachable;
+            const old_running = l.toBoolean(-1);
+            l.pop(1);
+            l.pushBoolean(running);
+            l.setUserValue(1, 5) catch unreachable;
+            if (!old_running and running) {
+                const wheel = lu.getWheel(l);
+                const now = wheel.timer.read();
+                l.pushInteger(@bitCast(now));
+                l.setUserValue(1, 6) catch unreachable; // current time (in ns): 6
+                const timer = l.checkUserdata(xev.Timer, 1, "seamstress.Timer");
+                _ = l.getUserValue(1, 7) catch unreachable; // completion: 7
+                const c = l.toUserdata(xev.Completion, -1) catch unreachable;
+                _ = l.getUserValue(1, 2) catch unreachable; // delta: 2
+                const delta = l.toNumber(-1) catch unreachable;
+                l.pop(2);
+                l.pushInteger(1);
+                l.setUserValue(1, 4) catch unreachable; // stage: 4
+                const next: u64 = @intFromFloat(delta * std.time.ms_per_s);
+                l.pushValue(1);
+                const handle = l.ref(ziglua.registry_index) catch l.raiseErrorStr("unable to register timer!", .{});
+                timer.run(&wheel.loop, c, next, anyopaque, @ptrFromInt(@as(u32, @bitCast(handle))), bang);
+            }
+            return 0;
+        }
+        if (std.mem.eql(u8, "stage", key)) {
+            _ = l.checkNumber(3);
+            l.pushValue(3);
+            l.setUserValue(1, 4) catch unreachable; // stage: 4
+            return 0;
+        }
+        if (std.mem.eql(u8, "stage_end", key)) {
+            _ = l.checkNumber(3);
+            l.pushValue(3);
+            l.setUserValue(1, 3) catch unreachable; // stage end: 3
+            return 0;
+        }
+        if (std.mem.eql(u8, "action", key)) {
+            lu.checkCallable(l, 3);
+            l.setUserValue(1, 1) catch unreachable; // action: 1
+            return 0;
+        }
+    }
+    _ = l.getUserValue(1, 8) catch unreachable; // data: 8
+    l.pushValue(2);
+    l.pushValue(3);
+    l.setTable(-3);
+    return 0;
+}
+
+const indices: [5]struct { []const u8, i32 } = .{
+    .{ "delta", 2 },
+    .{ "running", 5 },
+    .{ "stage", 4 },
+    .{ "stage_end", 3 },
+    .{ "action", 1 },
+};
+
+const ziglua = @import("ziglua");
+const Lua = ziglua.Lua;
+const xev = @import("xev");
+const lu = @import("lua_util.zig");
+const std = @import("std");
+const panic = std.debug.panic;
+const Wheel = @import("wheel.zig");
+const logger = std.log.scoped(.timer);

--- a/src/wheel.zig
+++ b/src/wheel.zig
@@ -5,10 +5,6 @@ loop: xev.Loop,
 pool: xev.ThreadPool,
 quit_flag: bool = false,
 awake: xev.Async,
-render: ?struct {
-    ctx: *anyopaque,
-    render_fn: *const fn (*anyopaque, *Wheel, u64) void,
-} = null,
 timer: std.time.Timer,
 kind: Seamstress.Cleanup = switch (builtin.mode) {
     .Debug, .ReleaseSafe => .full,
@@ -44,8 +40,6 @@ pub fn run(self: *Wheel) void {
     timer.run(&self.loop, &c3, 0, Lua, seamstress.l, callInit);
     while (!self.quit_flag) {
         self.loop.run(.once) catch |err| panic("error running event loop! {s}", .{@errorName(err)});
-        const lap_time = self.timer.lap();
-        if (self.render) |r| r.render_fn(r.ctx, self, lap_time) else std.log.debug("whoopsie", .{});
         if (seamstress.logger) |l| l.flush() catch unreachable;
     }
 }


### PR DESCRIPTION
event listeners may now optionally return a second value; all non-nil values will be presented to the caller of `seamstress.event.publish` as an array. (this is cribbed very heavily from mediator_lua.) in the case of `{ 'tui', ... }` events raised by seamstress itself, if any of the returned values are truthy, a draw event is triggered. by default, the last responder (priority 0) to `draw` calls `seamstress.tui.renderCommit` to actually push the updated cells to the terminal.

this commit adds `Timer` to the Lua layer, similar to `metro` from norns / seamstress 1. some differences: no new threads are spawned, so there is no limit on the number of timers. the timer has not gone back to sleep during the callback, so `pattern_time`-style dynamic timers should be much simpler to program. the type is entirely implemented in Zig, (yet memory is fully Lua-owned) so there is no actual `timer.lua` file. `seamstress.update` is available as a timer which will spawn an update-into-possible-draw event when enabled.

this represents partial progress towards #131.