### PR TITLE
feat!: export shared library for use with external lua processes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .paths = .{ "build.zig.zon", "build.zig", "src", "lua" },
     .dependencies = .{
         .ziglua = .{
-            .url = "git+https://github.com/natecraddock/ziglua?ref=main#5479e28d675c55e1e189bca99f71f0acbb3cc875",
-            .hash = "1220b53725744decfb2aba1269ae830b34ae30655154ba1144a8e722f9220cbbf0b0",
+            .url = "git+https://github.com/robbielyman/ziglua?ref=byo-lua#69a86667f31257e8529a3d20e1799283984bead5",
+            .hash = "12202e945f7d80689f48333beefd8a1993f3a67ca6af400d9c746f1a121fc7cb78fa",
         },
         .libxev = .{
             .url = "git+https://github.com/robbielyman/libxev?ref=cancel_udpsend#9fd748607d0b7295bd15e07676a0cfb954df579f",

--- a/lua/core/test.lua
+++ b/lua/core/test.lua
@@ -149,7 +149,7 @@ local function runner()
 
   local execute = require 'busted.execute' (busted)
   execute(1, {})
-  seamstress.quit()
+  seamstress:stop()
 end
 
 event.addSubscriber({ 'init' }, function()
@@ -159,6 +159,6 @@ event.addSubscriber({ 'init' }, function()
     return false
   end
   print(busted)
-  seamstress.quit()
+  seamstress:stop()
   return false
 end)

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,142 +1,213 @@
 const Cli = @This();
 const max_input_len = 2 * 1024;
 
-buffer: std.ArrayList(u8),
+buffer: std.ArrayListUnmanaged(u8) = .{},
 c: xev.Completion = .{},
 c_c: xev.Completion = .{},
 stdin: Stdin,
+running: bool = true,
 
-/// creates the input buffer and xev.File associated to this struct
-pub fn init(allocator: std.mem.Allocator) !Cli {
-    return .{
-        .buffer = std.ArrayList(u8).init(allocator),
-        .stdin = Stdin.init(),
-    };
+pub fn register(l: *Lua) i32 {
+    const cli = l.newUserdata(Cli, 0);
+    cli.* = .{ .stdin = Stdin.init() };
+    blk: {
+        l.newMetatable("seamstress.cli") catch break :blk;
+        const funcs: []const ziglua.FnReg = &.{
+            .{ .name = "__gc", .func = ziglua.wrap(__gc) },
+            .{ .name = "__index", .func = ziglua.wrap(__index) },
+            .{ .name = "__newindex", .func = ziglua.wrap(__newindex) },
+            .{ .name = "__cancel", .func = ziglua.wrap(__cancel) },
+        };
+        l.setFuncs(funcs, 0);
+    }
+    l.pop(1);
+    _ = l.getMetatableRegistry("seamstress.cli");
+    l.setMetatable(-2);
+    setup(l) catch l.raiseErrorStr("unable to start CLI!", .{});
+    return 1;
 }
 
 /// reads from the xev.File by using the event loop
-pub fn setup(self: *Cli) !void {
-    try self.buffer.ensureUnusedCapacity(max_input_len);
-    const seamstress: *Seamstress = @fieldParentPtr("cli", self);
+fn setup(lua: *Lua) !void {
+    const self = try lua.toUserdata(Cli, -1);
+    self.running = true;
+    try self.buffer.ensureUnusedCapacity(lua.allocator(), max_input_len);
+    const seamstress = lu.getSeamstress(lua);
+    lua.pushValue(-1); // ref pops
+    const h = try lua.ref(ziglua.registry_index);
+    if (!builtin.is_test) try std.io.getStdOut().writeAll("> ");
     self.stdin.read(&seamstress.loop, &self.c, .{
         .slice = self.buffer.unusedCapacitySlice(),
-    }, Cli, self, struct {
+    }, anyopaque, lu.ptrFromHandle(h), struct {
         fn stdinCallback(
-            m_cli: ?*Cli,
+            ptr: ?*anyopaque,
             loop: *xev.Loop,
             c: *xev.Completion,
-            file: Stdin,
+            _: Stdin,
             _: xev.ReadBuffer,
             r: xev.ReadError!usize,
         ) xev.CallbackAction {
-            const cli = m_cli.?;
-            const s: *Seamstress = @fieldParentPtr("cli", cli);
+            const l = lu.getLua(loop);
+            const handle = lu.handleFromPtr(ptr);
+            _ = l.rawGetIndex(ziglua.registry_index, handle);
+            const cli = l.toUserdata(Cli, -1) catch unreachable;
+
             const length = r catch |err| {
+                const str = @errorName(err);
+                l.unref(ziglua.registry_index, handle);
+                cli.running = false;
                 if (err != error.Canceled and err != error.EOF)
-                    logger.err("error reading from stdin! {s}", .{@errorName(err)});
-                if (err == error.EOF)
-                    lu.quit(s.lua);
-                return .disarm;
-            };
-            cli.buffer.items.len += length;
-            if (std.mem.eql(u8, "quit\n", cli.buffer.items)) {
-                lu.quit(s.lua);
-                return .disarm;
-            }
-            var buf = std.io.bufferedWriter(std.io.getStdOut().writer());
-            const stdout = buf.writer();
-            const was_complete = lu.processChunk(s.lua, cli.buffer.items) catch blk: {
-                stdout.print("{s}\n", .{s.lua.toString(-1) catch unreachable}) catch |err| {
-                    logger.err("unable to write to stdout! {s}", .{@errorName(err)});
-                    s.lua.setTop(0);
-                    return .disarm;
-                };
-                s.lua.pop(1);
-                break :blk true;
-            };
-            defer s.lua.setTop(0);
-            if (was_complete) {
-                cli.buffer.clearRetainingCapacity();
-                const n = s.lua.getTop();
-                var i: i32 = 1;
-                while (i <= n) : (i += 1) {
-                    switch (s.lua.typeOf(i)) {
-                        .number => if (s.lua.isInteger(i)) {
-                            stdout.print("{d}", .{s.lua.toInteger(i) catch unreachable}) catch |err| {
-                                logger.err("unable to write to stdout! {s}", .{@errorName(err)});
-                                return .disarm;
-                            };
-                        } else {
-                            stdout.print("{d}", .{s.lua.toNumber(i) catch unreachable}) catch |err| {
-                                logger.err("unable to write to stdout! {s}", .{@errorName(err)});
-                                return .disarm;
-                            };
-                        },
-                        .string => stdout.print("{s}", .{s.lua.toString(i) catch unreachable}) catch |err| {
-                            logger.err("unable to write to stdout! {s}", .{@errorName(err)});
-                            return .disarm;
-                        },
-                        .nil => stdout.print("nil", .{}) catch |err| {
-                            logger.err("unable to write to stdout! {s}", .{@errorName(err)});
-                            return .disarm;
-                        },
-                        .boolean => stdout.print("{s}", .{if (s.lua.toBoolean(i)) "true" else "false"}) catch |err| {
-                            logger.err("unable to write to stdout! {s}", .{@errorName(err)});
-                            return .disarm;
-                        },
-                        else => stdout.print("{s}", .{s.lua.toStringEx(i)}) catch |err| {
-                            logger.err("unable to write to stdout! {s}", .{@errorName(err)});
-                            return .disarm;
-                        },
-                    }
-                    stdout.writeAll(if (i != n) "\t" else "\n") catch |err| {
-                        logger.err("unable to write to stdout! {s}", .{@errorName(err)});
-                        return .disarm;
+                    logger.err("error reading from stdin! {s}", .{str});
+                if (err == error.EOF) {
+                    lu.load(l, "seamstress");
+                    _ = l.getField(-1, "stop");
+                    l.rotate(-2, 1);
+                    lu.doCall(l, 1, 0) catch {
+                        lu.reportError(l);
                     };
                 }
-            }
-            stdout.writeAll(if (was_complete) "> " else ">... ") catch |err| {
-                logger.err("unable to write to stdout! {s}", .{@errorName(err)});
                 return .disarm;
             };
+            l.pop(1);
+
+            cli.buffer.items.len += length;
+            if (std.mem.eql(u8, "quit\n", cli.buffer.items)) {
+                l.unref(ziglua.registry_index, handle);
+                cli.running = false;
+                lu.load(l, "seamstress");
+                _ = l.getField(-1, "stop");
+                l.rotate(-2, 1);
+                lu.doCall(l, 1, 0) catch {
+                    lu.reportError(l);
+                };
+                return .disarm;
+            }
+            var keep_going = true;
+            defer if (!keep_going) {
+                l.unref(ziglua.registry_index, handle);
+                cli.running = false;
+            };
+            var buf = std.io.bufferedWriter(if (!builtin.is_test)
+                std.io.getStdOut().writer()
+            else
+                std.io.null_writer);
+            const stdout = buf.writer();
+            lu.load(l, "seamstress.repl");
+            _ = l.pushString(cli.buffer.items);
+            lu.doCall(l, 1, ziglua.mult_return) catch {
+                lu.reportError(l);
+                cli.buffer.clearRetainingCapacity();
+                cli.buffer.ensureUnusedCapacity(lu.allocator(l), max_input_len) catch
+                    logger.warn("out of memory; unable to grow input buffer!", .{});
+                cli.stdin.read(loop, c, .{
+                    .slice = cli.buffer.unusedCapacitySlice(),
+                }, anyopaque, ptr, @This().stdinCallback);
+                return .disarm;
+            };
+            defer l.setTop(0);
+            if (l.getTop() > 0 and l.typeOf(-1) == .string and std.mem.endsWith(u8, l.toString(-1) catch unreachable, "<eof>")) {
+                stdout.writeAll(">... ") catch |err| {
+                    logger.err("unable to write to stdout! {s}", .{@errorName(err)});
+                    keep_going = false;
+                    return .disarm;
+                };
+            } else { // complete; let's print
+                cli.buffer.clearRetainingCapacity();
+                printAll(l, stdout) catch |err| {
+                    logger.err("unable to write to stdout! {s}", .{@errorName(err)});
+                    keep_going = false;
+                    return .disarm;
+                };
+                stdout.writeAll("> ") catch |err| {
+                    logger.err("unable to write to stdout! {s}", .{@errorName(err)});
+                    keep_going = false;
+                    return .disarm;
+                };
+            }
             buf.flush() catch |err| {
                 logger.err("unable to write to stdout! {s}", .{@errorName(err)});
+                keep_going = false;
                 return .disarm;
             };
-            cli.buffer.ensureUnusedCapacity(max_input_len) catch
+            cli.buffer.ensureUnusedCapacity(lu.allocator(l), max_input_len) catch
                 logger.warn("out of memory; unable to grow input buffer!", .{});
-            file.read(loop, c, .{
+            cli.stdin.read(loop, c, .{
                 .slice = cli.buffer.unusedCapacitySlice(),
-            }, Cli, cli, @This().stdinCallback);
+            }, anyopaque, ptr, @This().stdinCallback);
             return .disarm;
         }
     }.stdinCallback);
-    seamstress.lua.pushLightUserdata(self);
-    seamstress.lua.pushClosure(ziglua.wrap(struct {
-        fn f(l: *Lua) i32 {
-            const i = Lua.upvalueIndex(1);
-            const cli = l.toUserdata(Cli, i) catch unreachable;
-            cli.cancel();
-            return 0;
-        }
-    }.f), 1);
-    lu.addExitHandler(seamstress.lua, .quit);
 }
 
-/// stops reading from stdin
-/// pub so that (for example) the TUI library can find it
-pub fn cancel(self: *Cli) void {
-    const seamstress: *Seamstress = @fieldParentPtr("cli", self);
+fn printAll(l: *Lua, stdout: anytype) !void {
+    const n = l.getTop();
+    var i: i32 = 1;
+    while (i <= n) : (i += 1) {
+        switch (l.typeOf(i)) {
+            .number => if (l.isInteger(i)) {
+                try stdout.print("{d}", .{l.toInteger(i) catch unreachable});
+            } else {
+                try stdout.print("{d}", .{l.toNumber(i) catch unreachable});
+            },
+            .string => try stdout.print("{s}", .{l.toString(i) catch unreachable}),
+            .nil => try stdout.print("nil", .{}),
+            .boolean => try stdout.print("{s}", .{if (l.toBoolean(i)) "true" else "false"}),
+            else => try stdout.print("{s}", .{l.toStringEx(i)}),
+        }
+        try stdout.writeAll(if (i != n) "\t" else "\n");
+    }
+}
+
+fn __cancel(l: *Lua) i32 {
+    const self = l.checkUserdata(Cli, 1, "seamstress.cli");
+    if (!self.running) return 0;
+    self.running = false;
+    const seamstress = lu.getSeamstress(l);
+    l.pushValue(1);
+    const handle = l.ref(ziglua.registry_index) catch l.raiseErrorStr("unable to register CLI!", .{});
     self.c_c = .{
         .op = .{ .cancel = .{ .c = &self.c } },
-        .callback = xev.noopCallback,
+        .userdata = lu.ptrFromHandle(handle),
+        .callback = lu.unrefCallback,
     };
     seamstress.loop.add(&self.c_c);
+    return 0;
 }
 
-/// frees buffer memory
-pub fn deinit(self: *Cli) void {
-    self.buffer.deinit();
+fn __gc(l: *Lua) i32 {
+    const self = l.checkUserdata(Cli, 1, "seamstress.cli");
+    self.buffer.deinit(lu.allocator(l));
+    return 0;
+}
+
+fn __index(l: *Lua) i32 {
+    const cli = l.toUserdata(Cli, 1) catch unreachable;
+    _ = l.pushStringZ("running");
+    if (l.compare(-1, 2, .eq)) {
+        l.pushBoolean(cli.running);
+        return 1;
+    }
+    l.argError(2, "\"running\" expected");
+}
+
+fn __newindex(l: *Lua) i32 {
+    const cli = l.toUserdata(Cli, 1) catch unreachable;
+    _ = l.pushStringZ("running");
+    if (l.compare(-1, 2, .eq)) {
+        const running = l.toBoolean(3);
+        if (!cli.running and running) {
+            cli.running = true;
+            l.pushValue(1);
+            setup(l) catch l.raiseErrorStr("unable to start CLI!", .{});
+        } else if (cli.running and !running) {
+            cli.running = false;
+            l.pushFunction(ziglua.wrap(__cancel));
+            l.pushValue(1);
+            l.call(1, 0);
+        }
+        return 0;
+    }
+    l.argError(2, "\"running\" expected");
 }
 
 const logger = std.log.scoped(.cli);
@@ -148,3 +219,4 @@ const lu = @import("lua_util.zig");
 const ziglua = @import("ziglua");
 const Lua = ziglua.Lua;
 const Stdin = @import("cli/stdin.zig");
+const builtin = @import("builtin");

--- a/src/monome.zig
+++ b/src/monome.zig
@@ -42,7 +42,7 @@ fn populateSerialoscServer(l: *Lua) !void {
     const server_idx = l.getTop();
     const server = try l.toUserdata(osc.Server, -1);
     osc.pushAddress(l, .array, server.addr);
-    var builder = osc.z.Message.Builder.init(l.allocator());
+    var builder = osc.z.Message.Builder.init(lu.allocator(l));
     defer builder.deinit();
     _ = l.getIndex(-1, 1);
     _ = l.getIndex(-2, 2);
@@ -50,7 +50,7 @@ fn populateSerialoscServer(l: *Lua) !void {
     const portnum = try l.toInteger(-1);
     try builder.append(.{ .s = host });
     try builder.append(.{ .i = std.math.cast(i32, portnum) orelse return error.BadPort });
-    const m = try builder.commit(l.allocator(), "/serialosc/notify");
+    const m = try builder.commit(lu.allocator(l), "/serialosc/notify");
     defer m.unref();
     l.pop(3);
     l.newTable(); // t
@@ -74,7 +74,7 @@ fn populateSerialoscServer(l: *Lua) !void {
     l.rotate(-2, 1);
     l.setTable(server_idx); // serialosc[addr] = c
 
-    const m2 = try builder.commit(l.allocator(), "/serialosc/list");
+    const m2 = try builder.commit(lu.allocator(l), "/serialosc/list");
     defer m2.unref();
     try server.sendOSCBytes(serialosc_addr, m2.toBytes()); // send /serialosc/list
     try server.sendOSCBytes(serialosc_addr, m.toBytes()); // send /serialosc/notify

--- a/src/monome/arc.zig
+++ b/src/monome/arc.zig
@@ -89,7 +89,7 @@ fn refresh(l: *Lua) i32 {
         _ = l.getIndex(-1, @intCast(i + 1));
         const builder = l.toUserdata(osc.z.Message.Builder, -1) catch unreachable;
         builder.data.items[0] = .{ .i = @intCast(i) };
-        const msg = builder.commit(l.allocator(), path) catch l.raiseErrorStr("out of memory!", .{});
+        const msg = builder.commit(lu.allocator(l), path) catch l.raiseErrorStr("out of memory!", .{});
         defer msg.unref();
         arc.dirty[i] = false;
         server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {

--- a/src/monome/common.zig
+++ b/src/monome/common.zig
@@ -191,7 +191,7 @@ pub fn __newindex(comptime which: enum { grid, arc }) fn (*Lua) i32 {
                     .one_eighty => 180,
                     .two_seventy => 270,
                 };
-                const msg = osc.z.Message.fromTuple(l.allocator(), "/sys/rotation", .{rot}) catch
+                const msg = osc.z.Message.fromTuple(lu.allocator(l), "/sys/rotation", .{rot}) catch
                     l.raiseErrorStr("out of memory!", .{});
                 defer msg.unref();
                 server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {
@@ -221,7 +221,7 @@ pub fn __newindex(comptime which: enum { grid, arc }) fn (*Lua) i32 {
                 l.setTable(-3);
                 _ = l.getField(1, "client");
                 const client = l.toUserdata(osc.Client, -1) catch unreachable;
-                const msg = osc.z.Message.fromTuple(l.allocator(), "/sys/prefix", .{actual_prefix}) catch
+                const msg = osc.z.Message.fromTuple(lu.allocator(l), "/sys/prefix", .{actual_prefix}) catch
                     l.raiseErrorStr("out of memory!", .{});
                 defer msg.unref();
                 server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {
@@ -291,7 +291,7 @@ pub fn @"/sys/info"(l: *Lua) i32 {
     const host = l.toString(-1) catch unreachable;
     _ = l.getIndex(-2, 2);
     const port: i32 = @intCast(l.toInteger(-1) catch unreachable);
-    const msg = osc.z.Message.fromTuple(l.allocator(), "/sys/info", .{ host, port }) catch
+    const msg = osc.z.Message.fromTuple(lu.allocator(l), "/sys/info", .{ host, port }) catch
         l.raiseErrorStr("out of memory!", .{});
     defer msg.unref();
     server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {
@@ -365,7 +365,7 @@ pub fn connect(comptime which: enum { grid, arc }) fn (*Lua) i32 {
             _ = l.getIndex(-2, 2);
             const port = l.toInteger(-1) catch unreachable;
             {
-                const msg = osc.z.Message.fromTuple(l.allocator(), "/sys/host", .{host}) catch
+                const msg = osc.z.Message.fromTuple(lu.allocator(l), "/sys/host", .{host}) catch
                     l.raiseErrorStr("out of memory!", .{});
                 defer msg.unref();
                 server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {
@@ -374,7 +374,7 @@ pub fn connect(comptime which: enum { grid, arc }) fn (*Lua) i32 {
                 };
             }
             {
-                const msg = osc.z.Message.fromTuple(l.allocator(), "/sys/port", .{@as(i32, @intCast(port))}) catch
+                const msg = osc.z.Message.fromTuple(lu.allocator(l), "/sys/port", .{@as(i32, @intCast(port))}) catch
                     l.raiseErrorStr("out of memory!", .{});
                 defer msg.unref();
                 server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {

--- a/src/monome/grid.zig
+++ b/src/monome/grid.zig
@@ -102,7 +102,7 @@ fn refresh(l: *Lua) i32 {
             const builder = l.toUserdata(osc.z.Message.Builder, -1) catch unreachable;
             builder.data.items[0] = .{ .i = 0 };
             builder.data.items[1] = .{ .i = 0 };
-            const msg = builder.commit(l.allocator(), path) catch l.raiseErrorStr("out of memory!", .{});
+            const msg = builder.commit(lu.allocator(l), path) catch l.raiseErrorStr("out of memory!", .{});
             defer msg.unref();
             grid.dirty[0] = false;
             server.sendOSCBytes(client.addr, msg.toBytes()) catch |err|
@@ -121,7 +121,7 @@ fn refresh(l: *Lua) i32 {
                 const builder = l.toUserdata(osc.z.Message.Builder, -1) catch unreachable;
                 builder.data.items[0] = .{ .i = x_off[i] };
                 builder.data.items[1] = .{ .i = y_off[i] };
-                const msg = builder.commit(l.allocator(), path) catch l.raiseErrorStr("out of memory!", .{});
+                const msg = builder.commit(lu.allocator(l), path) catch l.raiseErrorStr("out of memory!", .{});
                 defer msg.unref();
                 grid.dirty[@intCast(j)] = false;
                 server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {
@@ -138,7 +138,7 @@ fn refresh(l: *Lua) i32 {
                 const builder = l.toUserdata(osc.z.Message.Builder, -1) catch unreachable;
                 builder.data.items[0] = .{ .i = x_off[i] };
                 builder.data.items[1] = .{ .i = y_off[i] };
-                const msg = builder.commit(l.allocator(), path) catch l.raiseErrorStr("out of memory!", .{});
+                const msg = builder.commit(lu.allocator(l), path) catch l.raiseErrorStr("out of memory!", .{});
                 defer msg.unref();
                 grid.dirty[@intCast(i)] = false;
                 server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {
@@ -162,7 +162,7 @@ fn tiltEnable(l: *Lua) i32 {
     _ = l.pushString("/tilt/set");
     l.concat(2);
     const path = l.toString(-1) catch unreachable;
-    const msg = osc.z.Message.fromTuple(l.allocator(), path, .{ sensor, @as(i32, if (enable) 1 else 0) }) catch
+    const msg = osc.z.Message.fromTuple(lu.allocator(l), path, .{ sensor, @as(i32, if (enable) 1 else 0) }) catch
         l.raiseErrorStr("out of memory!", .{});
     defer msg.unref();
     server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {
@@ -302,7 +302,7 @@ fn intensity(l: *Lua) i32 {
     _ = l.pushStringZ("/grid/led/intensity");
     l.concat(2);
     const path = l.toString(-1) catch unreachable;
-    const msg = osc.z.Message.fromTuple(l.allocator(), path, .{@as(i32, @intCast(level))}) catch
+    const msg = osc.z.Message.fromTuple(lu.allocator(l), path, .{@as(i32, @intCast(level))}) catch
         l.raiseErrorStr("out of memory!", .{});
     defer msg.unref();
     server.sendOSCBytes(client.addr, msg.toBytes()) catch |err| {

--- a/src/osc/client.zig
+++ b/src/osc/client.zig
@@ -80,7 +80,7 @@ fn dispatchWhich(l: *Lua, comptime which: enum { bytes, msg }) void {
                         if (l.typeOf(5) == .nil) {
                             // we have to create the bytes
                             const msg = l.checkUserdata(z.Message.Builder, 2, "seamstress.osc.Message");
-                            const m = msg.commit(l.allocator(), path) catch l.raiseErrorStr("out of memory!", .{});
+                            const m = msg.commit(lu.allocator(l), path) catch l.raiseErrorStr("out of memory!", .{});
                             defer m.unref();
                             _ = l.pushString(m.toBytes());
                             l.replace(5);

--- a/src/osc/message.zig
+++ b/src/osc/message.zig
@@ -152,7 +152,7 @@ fn bytes(l: *Lua) i32 {
     if (l.getUserValue(1, 1) catch unreachable != .string) l.raiseErrorStr("missing or invalid OSC path!", .{});
     const path = l.toString(-1) catch unreachable;
     // build a message
-    const msg = builder.commit(l.allocator(), path) catch l.raiseErrorStr("out of memory!", .{});
+    const msg = builder.commit(lu.allocator(l), path) catch l.raiseErrorStr("out of memory!", .{});
     // be sure to release it
     defer msg.unref();
     // return the bytes
@@ -166,7 +166,7 @@ fn bytes(l: *Lua) i32 {
 fn new(l: *Lua) i32 {
     const arg_exists = l.getTop() != 0;
     const builder = l.newUserdata(z.Message.Builder, 1); // create a builder
-    builder.* = z.Message.Builder.init(l.allocator()); // initialize
+    builder.* = z.Message.Builder.init(lu.allocator(l)); // initialize
     if (arg_exists) {
         // set path
         if (l.getField(1, "path") != .string) {

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1,0 +1,58 @@
+pub fn register(l: *Lua) i32 {
+    l.pushFunction(ziglua.wrap(repl));
+    return 1;
+}
+
+fn repl(l: *Lua) i32 {
+    const input = l.checkString(1);
+    const top = l.getTop();
+    return switch (processChunk(l, input) catch l.raiseError()) {
+        .ok => l.getTop() - top,
+        .incomplete => 1,
+    };
+}
+
+/// processes the buffer as plaintext Lua code
+/// stack effect: essentially arbitrary: usually you should subsequently call `print`
+fn processChunk(l: *Lua, buffer: []const u8) !enum { ok, incomplete } {
+    lu.format(l, "return {s}", .{buffer});
+    const with_return = l.toString(-1) catch unreachable;
+    l.pop(1);
+    // loads the chunk...
+    l.loadBuffer(with_return, "=repl", .text) catch |err| {
+        // ... if the chunk does not compile
+        switch (err) {
+            error.Memory => return error.OutOfMemory,
+            error.Syntax => {
+                // remove the error message
+                l.pop(1);
+                // load the original buffer
+                l.loadBuffer(buffer, "=repl", .text) catch |err2| switch (err2) {
+                    error.Memory => return error.OutOfMemory,
+                    error.Syntax => {
+                        const msg = l.toStringEx(-1);
+                        // does the syntax error tell us the statement isn't finished?
+                        if (std.mem.endsWith(u8, msg, "<eof>")) {
+                            return .incomplete;
+                        } else {
+                            // return an error to signal the syntax error
+                            return error.LuaSyntaxError;
+                        }
+                    },
+                };
+            },
+        }
+        // call the compiled function
+        try lu.doCall(l, 0, ziglua.mult_return);
+        return .ok;
+    };
+    // ... the chunk compiles fine with "return " added!
+    // call the compiled function
+    try lu.doCall(l, 0, ziglua.mult_return);
+    return .ok;
+}
+
+const ziglua = @import("ziglua");
+const Lua = ziglua.Lua;
+const lu = @import("lua_util.zig");
+const std = @import("std");

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,0 +1,9 @@
+export fn luaopen_seamstress(l: ?*ziglua.LuaState) c_int {
+    const lua: *Lua = @ptrCast(l.?);
+    return @call(.always_inline, Seamstress.register, .{lua});
+}
+
+const Seamstress = @import("seamstress.zig");
+const std = @import("std");
+const ziglua = @import("ziglua");
+const Lua = ziglua.Lua;

--- a/src/seamstress.zig
+++ b/src/seamstress.zig
@@ -1,239 +1,55 @@
-// zig files double as namespaces / struct types
 const Seamstress = @This();
 
 loop: xev.Loop,
 pool: xev.ThreadPool,
 lua: *Lua,
-cli: Cli,
+status: enum { suspended, running } = .suspended,
 
-/// creates lua environment and event loop
-pub fn init(self: *Seamstress, alloc_ptr: *const std.mem.Allocator) !void {
-    self.* = .{
-        .loop = undefined,
-        .pool = xev.ThreadPool.init(.{ .max_threads = 16 }),
-        .lua = try Lua.init(alloc_ptr),
-        .cli = try Cli.init(alloc_ptr.*),
-    };
-    self.loop = try xev.Loop.init(.{ .thread_pool = &self.pool });
-}
-
-pub fn run(self: *Seamstress) !void {
-    // we want a zig stack trace
-    _ = self.lua.atPanic(ziglua.wrap(struct {
-        fn panic(l: *Lua) i32 { // function panic(error_msg)
-            const error_msg = l.toStringEx(-1);
-            l.pop(1);
-            // add a lua stack trace
-            l.traceback(l, error_msg, 1); // local with_stack_trace = debug.traceback(error_msg, 1)
-            const with_stack_trace = l.toString(-1) catch unreachable;
-            l.pop(1);
-            // and panic!
-            @call(.always_inline, std.debug.panic, .{ "lua crashed: {s}", .{with_stack_trace} });
-            return 0; // never reached, since std.debug.panic has return type noreturn
-        }
-    }.panic));
-    // prepare the lua environment
-    try self.setup();
-    var c: xev.Completion = .{};
-    self.loop.timer(&c, 0, self, struct {
-        fn f(ud: ?*anyopaque, _: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
-            const s: *Seamstress = @ptrCast(@alignCast(ud.?));
-            blk: {
-                const args = std.process.argsAlloc(s.lua.allocator()) catch break :blk;
-                defer std.process.argsFree(s.lua.allocator(), args);
-                if (args.len < 2) break :blk;
-                if (std.mem.eql(u8, "test", args[1])) break :blk;
-                if (builtin.is_test) break :blk;
-                s.lua.doFile(args[1]) catch {
-                    lu.reportError(s.lua);
-                };
-            }
-            lu.preparePublish(s.lua, &.{"init"});
-            lu.doCall(s.lua, 1, 0) catch {
-                lu.reportError(s.lua);
-                return .disarm;
-            };
-            _ = r.timer catch return .disarm;
-            return .disarm;
-        }
-    }.f);
-    try self.loop.run(.until_done);
-}
-
-/// closes the event loop, lua instance, frees memory
-pub fn deinit(self: *Seamstress) void {
-    self.loop.deinit();
-    self.lua.close();
-    self.cli.deinit();
-    self.* = undefined;
-}
-
-// pub because it is referenced in main
-pub fn panicCleanup(s: *Seamstress) void {
-    @setCold(true);
-    _ = s.lua.getMetatableRegistry("seamstress");
-    _ = s.lua.getField(-1, "__panic");
-    lu.doCall(s.lua, 0, 0) catch {
-        // write to stderr because there's no guarantee the logs will be flushed
-        std.debug.print("{s}\n", .{s.lua.toString(-1) catch unreachable});
-    };
-}
-
-/// single source of truth about seamstress version
-pub const version: std.SemanticVersion = .{
-    .major = 2,
-    .minor = 0,
-    .patch = 0,
-    .pre = "prealpha",
-    .build = "241005",
-};
-
-fn setup(self: *Seamstress) !void {
-    const allocator = self.lua.allocator();
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
-    const is_test = is_test: {
-        if (args.len < 2) break :is_test false;
-        break :is_test std.mem.eql(u8, args[1], "test");
-    };
-    // open standard lua libraries
-    self.lua.openLibs();
-    // load the config file---unless we're running tests
-    // the config file leaves a table on the stack
-    if (!is_test and !builtin.is_test) try self.configure();
-    // create the seamstress metatable
-    try self.createMetatable();
-    // add our package searcher
-    try addPackageSearcher(self.lua);
-    // populates "seamstress" as a lua global and leaves it on the stack
-    self.lua.requireF("seamstress", ziglua.wrap(register), true);
-    if (!builtin.is_test) if (is_test) {
-        // adds an `init` handler that runs the seamstress tests
-        lu.load(self.lua, "seamstress.test");
-    } else {
-        self.lua.rotate(-2, 1);
-        // seamstress.config = the table returned by config
-        self.lua.setField(-2, "config");
-    };
-    self.lua.pop(1); // pop seamstress from the stack
-    // set up CLI interaction
-    try self.cli.setup();
-    self.lua.pushFunction(ziglua.wrap(clearRegistry));
-    lu.addExitHandler(self.lua, .quit);
-}
-
-/// attempts to call `dofile` on $SEAMSTRESS_HOME/$SEAMSTRESS_CONFIG_FILENAME
-/// and then scrapes any new globals added into a table, which is left on the stack
-fn configure(seamstress: *Seamstress) !void {
-    const script =
-        \\return function()
-        \\  local not_new = {}
-        \\  for key, _ in pairs(_G) do
-        \\    table.insert(not_new, key)
-        \\  end
-        \\  local config_file = os.getenv("SEAMSTRESS_HOME") ..
-        \\    package.config:sub(1, 1) ..
-        \\    os.getenv("SEAMSTRESS_CONFIG_FILENAME")
-        \\  local ok, err = pcall(dofile, config_file)
-        \\  if not ok then
-        \\    if err:find("No such file or directory") then return {} end
-        \\    error(err)
-        \\  end
-        \\  local ret = {}
-        \\  for key, value in pairs(_G) do
-        \\    local found = false
-        \\    for _, other in ipairs(not_new) do
-        \\      if key == other then
-        \\        found = true
-        \\        break
-        \\      end
-        \\    end
-        \\    if found == false then
-        \\      ret[key] = value
-        \\      _G[key] = nil
-        \\    end
-        \\  end
-        \\  return ret
-        \\end
-    ;
-    try seamstress.lua.loadString(script);
-    try lu.doCall(seamstress.lua, 0, 1);
-    try lu.doCall(seamstress.lua, 0, 1);
-}
-
-fn createMetatable(seamstress: *Seamstress) !void {
-    try seamstress.lua.newMetatable("seamstress"); // local mt = {}
-    seamstress.lua.pushLightUserdata(seamstress); // ptr
-    seamstress.lua.setField(-2, "__seamstress"); // mt.__seamstress = ptr
-    const inner = struct {
-        const Which = enum { panic, quit };
-
-        fn postEventAndCallAllFunctionsInTable(comptime which: Which) fn (*Lua) i32 {
-            return struct {
-                fn f(l: *Lua) i32 {
-                    lu.preparePublish(l, &.{switch (which) {
-                        .panic => "panic",
-                        .quit => "quit",
-                    }});
-                    lu.doCall(l, 1, 0) catch {
-                        std.log.scoped(.seamstress).err("error in event handler: {s}", .{l.toString(-1) catch unreachable});
-                        l.pop(1);
-                    };
-                    const i = Lua.upvalueIndex(1);
-                    l.pushNil();
-                    while (l.next(i)) {
-                        if (lu.isCallable(l, -1)) {
-                            lu.doCall(l, 0, 0) catch {
-                                std.log.scoped(.seamstress).err("error in exit handler: {s}", .{l.toString(-1) catch unreachable});
-                                l.pop(1);
-                            };
-                        } else {
-                            l.pushValue(-2);
-                            const key = l.toStringEx(-1);
-                            const value = l.toStringEx(-2);
-                            std.log.scoped(.seamstress).err("exit handler at key {s} is not callable; value: {s}", .{ key, value });
-                            l.pop(2);
-                        }
-                    }
-                    return 0;
-                }
-            }.f;
-        }
-    };
-
-    seamstress.lua.newTable(); // {}
-    seamstress.lua.pushClosure(ziglua.wrap(inner.postEventAndCallAllFunctionsInTable(.quit)), 1); // f (closes over {})
-    seamstress.lua.setField(-2, "__quit"); // mt.__quit = f
-
-    seamstress.lua.newTable(); // {}
-    seamstress.lua.pushClosure(ziglua.wrap(inner.postEventAndCallAllFunctionsInTable(.panic)), 1); // f (closes over {})
-    seamstress.lua.setField(-2, "__panic"); // mt.__panic = f
-
-    seamstress.lua.pop(1); // pop mt
-}
-
-/// pub so that modules.zig can access it
 pub fn register(l: *Lua) i32 {
+    addPackageSearcher(l) catch l.raiseErrorStr("unable to add package searcher!", .{});
+    const seamstress = l.newUserdata(Seamstress, 1);
     l.newTable();
-    // TODO: fill this out more
     lu.load(l, "seamstress.event");
     l.setField(-2, "event");
     lu.load(l, "seamstress.async");
     l.setField(-2, "async");
     lu.load(l, "seamstress.Timer");
     l.setField(-2, "Timer");
-    l.pushFunction(ziglua.wrap(struct {
-        fn f(lua: *Lua) i32 {
-            lu.quit(lua);
-            return 0;
-        }
-    }.f));
-    l.setField(-2, "quit");
+    l.setUserValue(-2, 1) catch unreachable;
+    seamstress.init(l) catch l.raiseErrorStr("unable to create seamstress event loop!", .{});
+    blk: {
+        l.newMetatable("seamstress") catch break :blk;
+        const funcs: []const ziglua.FnReg = &.{
+            .{ .name = "__index", .func = ziglua.wrap(__index) },
+            .{ .name = "__newindex", .func = ziglua.wrap(__newindex) },
+            .{ .name = "run", .func = ziglua.wrap(run) },
+            .{ .name = "resume", .func = ziglua.wrap(@"resume") },
+            .{ .name = "__gc", .func = ziglua.wrap(__gc) },
+        };
+        l.setFuncs(funcs, 0);
+        l.newTable();
+        const stop_fns: []const ziglua.FnReg = &.{
+            .{ .name = "stop", .func = ziglua.wrap(stop) },
+        };
+        l.setFuncs(stop_fns, 1);
+        l.newTable();
+        const panic_fns: []const ziglua.FnReg = &.{
+            .{ .name = "panic", .func = ziglua.wrap(panic) },
+        };
+        l.setFuncs(panic_fns, 1);
+    }
+    l.pop(1);
+    _ = l.getMetatableRegistry("seamstress");
+    l.setMetatable(-2);
+    l.pushFunction(ziglua.wrap(clearRegistry));
+    lu.addExitHandler(l, .stop);
     return 1;
 }
 
 /// adds a "package searcher" to the Lua environment that handles calls to requiring seamstress modules
 fn addPackageSearcher(lua: *Lua) !void {
+    const top = if (builtin.mode == .Debug) lua.getTop();
+    defer if (builtin.mode == .Debug) std.debug.assert(top == lua.getTop());
     // package.searchers[#package.searchers + 1] = f
     _ = try lua.getGlobal("package");
     _ = lua.getField(-1, "searchers");
@@ -249,6 +65,204 @@ fn addPackageSearcher(lua: *Lua) !void {
     }.searcher));
     lua.rawSetIndex(-2, @intCast(lua.rawLen(-2) + 1)); // add our searcher to the end
     lua.pop(2); // pop `package` and `package.searchers`
+}
+
+pub fn init(self: *Seamstress, l: *Lua) !void {
+    self.* = .{
+        .pool = xev.ThreadPool.init(.{ .max_threads = 16 }),
+        .lua = l,
+        .loop = try xev.Loop.init(.{ .thread_pool = &self.pool }),
+    };
+}
+
+pub fn main(l: *Lua) !void {
+    l.openLibs();
+    // we want a zig stack trace
+    _ = l.atPanic(ziglua.wrap(struct {
+        fn panic(lua: *Lua) i32 { // function panic(error_msg)
+            const error_msg = lua.toStringEx(-1);
+            // add a lua stack trace
+            lua.traceback(lua, error_msg, 1); // local with_stack_trace = debug.traceback(error_msg, 1)
+            const with_stack_trace = lua.toString(-1) catch unreachable;
+            @call(.always_inline, std.debug.panic, .{ "lua crashed: {s}", .{with_stack_trace} });
+        }
+        // no need to return anything since std.debug.panic is of type noreturn
+    }.panic));
+    lu.load(l, "seamstress");
+    const seamstress = l.toUserdata(Seamstress, -1) catch unreachable;
+    l.setGlobal("seamstress");
+    lu.load(l, "seamstress.repl");
+    l.pop(1);
+    lu.load(l, "seamstress.cli");
+    l.pop(1);
+    var c: xev.Completion = .{};
+    seamstress.loop.timer(&c, 0, seamstress, struct {
+        fn f(ud: ?*anyopaque, _: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            const s: *Seamstress = @ptrCast(@alignCast(ud.?));
+            blk: {
+                const args = std.process.argsAlloc(s.lua.allocator()) catch break :blk;
+                defer std.process.argsFree(s.lua.allocator(), args);
+                if (args.len < 2) break :blk;
+                if (std.mem.eql(u8, "test", args[1])) {
+                    lu.load(s.lua, "seamstress.test");
+                    break :blk;
+                }
+                s.lua.doFile(args[1]) catch {
+                    lu.reportError(s.lua);
+                };
+            }
+            lu.preparePublish(s.lua, &.{"init"});
+            lu.doCall(s.lua, 1, 0) catch {
+                lu.reportError(s.lua);
+                return .disarm;
+            };
+            _ = r.timer catch return .disarm;
+            return .disarm;
+        }
+    }.f);
+    seamstress.status = .running;
+    try seamstress.loop.run(.until_done);
+}
+
+fn __index(l: *Lua) i32 {
+    const seamstress = l.checkUserdata(Seamstress, 1, "seamstress");
+    _ = l.pushStringZ("status");
+    if (l.compare(-1, 2, .eq)) {
+        _ = l.pushStringZ(@tagName(seamstress.status));
+        return 1;
+    }
+    _ = l.getUserValue(1, 1) catch unreachable;
+    l.pushValue(2);
+    switch (l.getTable(-2)) {
+        .nil, .none => {
+            l.getMetatable(1) catch unreachable;
+            l.pushValue(2);
+            _ = l.getTable(-2);
+            return 1;
+        },
+        else => return 1,
+    }
+}
+
+fn __newindex(l: *Lua) i32 {
+    _ = l.pushStringZ("status");
+    if (l.compare(-1, 2, .eq)) l.raiseErrorStr("unable to assign to seamstress.status!", .{});
+    _ = l.getUserValue(1, 1) catch unreachable;
+    l.pushValue(2);
+    l.pushValue(3);
+    l.setTable(-3);
+    return 0;
+}
+
+fn __gc(l: *Lua) i32 {
+    const seamstress = l.checkUserdata(Seamstress, 1, "seamstress");
+    seamstress.loop.deinit();
+    seamstress.pool.shutdown();
+    seamstress.pool.deinit();
+    seamstress.* = undefined;
+    return 0;
+}
+
+fn panic(l: *Lua) i32 {
+    const seamstress = l.checkUserdata(Seamstress, 1, "seamstress");
+    lu.preparePublish(l, &.{"panic"});
+    lu.doCall(l, 1, 0) catch {
+        std.log.scoped(.seamstress).err("error in event handler: {s}", .{l.toString(-1) catch unreachable});
+        lu.reportError(l);
+    };
+    const i = Lua.upvalueIndex(1);
+    l.pushNil();
+    while (l.next(i)) {
+        if (lu.isCallable(l, -1)) {
+            lu.doCall(l, 0, 0) catch {
+                std.log.scoped(.seamstress).err("error in panic handler: {s}", .{l.toString(-1) catch unreachable});
+                lu.reportError(l);
+            };
+        } else {
+            l.pushValue(-2);
+            const key = l.toStringEx(-1);
+            const value = l.toStringEx(-2);
+            l.pop(2);
+            lu.format(l, "panic handler at key {s} is not callable; value: {s}", .{ key, value });
+            std.log.scoped(.seamstress).err("{s}", .{l.toString(-1) catch unreachable});
+            lu.reportError(l);
+        }
+    }
+    if (seamstress.status == .suspended) {
+        std.debug.dumpCurrentStackTrace(@returnAddress());
+        std.process.exit(1);
+    }
+    return 0;
+}
+
+fn stop(l: *Lua) i32 {
+    const seamstress = l.checkUserdata(Seamstress, 1, "seamstress");
+    lu.preparePublish(l, &.{"stop"});
+    lu.doCall(l, 1, 0) catch {
+        std.log.scoped(.seamstress).err("error in event handler: {s}", .{l.toString(-1) catch unreachable});
+        lu.reportError(l);
+    };
+    const i = Lua.upvalueIndex(1);
+    l.pushNil();
+    while (l.next(i)) {
+        if (lu.isCallable(l, -1)) {
+            lu.doCall(l, 0, 0) catch {
+                std.log.scoped(.seamstress).err("error in stop handler: {s}", .{l.toString(-1) catch unreachable});
+                lu.reportError(l);
+            };
+        } else {
+            l.pushValue(-2);
+            const key = l.toStringEx(-1);
+            const value = l.toStringEx(-2);
+            l.pop(2);
+            lu.format(l, "stop handler at key {s} is not callable; value: {s}", .{ key, value });
+            lu.reportError(l);
+        }
+    }
+    if (seamstress.status == .suspended) seamstress.loop.run(.until_done) catch
+        l.raiseErrorStr("error running event loop!", .{});
+    return 0;
+}
+
+fn run(l: *Lua) i32 {
+    const seamstress = l.checkUserdata(Seamstress, 1, "seamstress");
+    const t = l.getTop();
+    if (t > 1) {
+        lu.checkCallable(l, 2);
+        lu.load(l, "seamstress.async.Promise");
+        l.insert(2);
+        l.call(t - 1, 0);
+        if (seamstress.status == .suspended) {
+            defer seamstress.status = .suspended;
+            seamstress.status = .running;
+            seamstress.loop.run(.until_done) catch
+                l.raiseErrorStr("error running event loop!", .{});
+        }
+    }
+    switch (seamstress.status) {
+        .suspended => {
+            seamstress.status = .running;
+            defer seamstress.status = .suspended;
+            seamstress.loop.run(.until_done) catch
+                l.raiseErrorStr("error running event loop!", .{});
+        },
+        .running => l.raiseErrorStr("seamstress object already running!", .{}),
+    }
+    return 0;
+}
+
+fn @"resume"(l: *Lua) i32 {
+    const seamstress = l.checkUserdata(Seamstress, 1, "seamstress");
+    switch (seamstress.status) {
+        .suspended => {
+            seamstress.status = .running;
+            defer seamstress.status = .suspended;
+            seamstress.loop.run(.once) catch
+                l.raiseErrorStr("error running event loop!", .{});
+        },
+        .running => l.raiseErrorStr("seamstress object already running!", .{}),
+    }
+    return 0;
 }
 
 /// creates a copy of the registry table and then, for each entry in the copy table,
@@ -273,7 +287,6 @@ fn clearRegistry(l: *Lua) i32 {
     }
     const len = index;
     index = 1;
-    // @breakpoint();
     while (index < len) : (index += 1) {
         _ = l.getIndex(tbl, index);
         _ = l.getMetaField(-1, "__cancel") catch {};
@@ -283,51 +296,74 @@ fn clearRegistry(l: *Lua) i32 {
     return 0;
 }
 
-const builtin = @import("builtin");
-const std = @import("std");
+pub fn panicCleanup(l: *Lua) void {
+    @setCold(true);
+    lu.load(l, "seamstress");
+    _ = l.getField(-1, "panic");
+    l.rotate(-2, 1);
+    lu.doCall(l, 1, 0) catch {
+        std.debug.print("{s}\n", .{l.toString(-1) catch unreachable});
+    };
+}
+
+pub const version: std.SemanticVersion = .{
+    .major = 2,
+    .minor = 0,
+    .patch = 0,
+    .pre = "prealpha",
+    .build = "241129",
+};
+
+const xev = @import("xev");
 const ziglua = @import("ziglua");
 const Lua = ziglua.Lua;
-const BufferedWriter = std.io.BufferedWriter(4096, std.fs.File.Writer);
-const xev = @import("xev");
-const modules = @import("modules.zig");
-const Cli = @import("cli.zig");
+const std = @import("std");
 const lu = @import("lua_util.zig");
+const modules = @import("modules.zig");
+const builtin = @import("builtin");
 
 test "ref" {
     _ = modules;
 }
 
 test "lifecycle" {
-    var seamstress: Seamstress = undefined;
-    try seamstress.init(&std.testing.allocator);
-    defer seamstress.deinit();
-
+    std.testing.log_level = .debug;
+    const l = try Lua.init(&std.testing.allocator);
+    defer l.deinit();
+    l.openLibs();
+    lu.load(l, "seamstress");
+    const seamstress = try l.toUserdata(Seamstress, -1);
     var c: xev.Completion = .{};
-    var failed: bool = false;
+    var failed = false;
     seamstress.loop.timer(&c, 1, &failed, struct {
-        fn f(ud: ?*anyopaque, loop: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
+        fn f(ud: ?*anyopaque, loop: *xev.Loop, d: *xev.Completion, r: xev.Result) xev.CallbackAction {
             _ = r.timer catch unreachable;
             const boolean: *bool = @ptrCast(@alignCast(ud.?));
-            const l = lu.getLua(loop);
+            const lua = lu.getLua(loop);
             for (modules.list.values()) |@"fn"| {
-                l.pushFunction(@"fn");
-                lu.doCall(l, 0, 0) catch {
-                    l.pop(1);
+                lua.pushFunction(@"fn");
+                lu.doCall(lua, 0, 0) catch {
+                    std.debug.print("{s}\n", .{lua.toString(-1) catch unreachable});
+                    lua.pop(1);
                     boolean.* = true;
                 };
             }
+            loop.timer(d, 500, lua, struct {
+                fn f(ptr: ?*anyopaque, _: *xev.Loop, _: *xev.Completion, res: xev.Result) xev.CallbackAction {
+                    _ = res.timer catch unreachable;
+                    const luaa: *Lua = @ptrCast(@alignCast(ptr.?));
+                    lu.load(luaa, "seamstress");
+                    _ = luaa.getField(-1, "stop");
+                    luaa.rotate(-2, 1);
+                    lu.doCall(luaa, 1, 0) catch return .disarm;
+                    return .disarm;
+                }
+            }.f);
             return .disarm;
         }
     }.f);
-    var d: xev.Completion = .{};
-    seamstress.loop.timer(&d, 1000, seamstress.lua, struct {
-        fn f(ud: ?*anyopaque, _: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
-            _ = r.timer catch unreachable;
-            const l: *Lua = @ptrCast(@alignCast(ud.?));
-            lu.quit(l);
-            return .disarm;
-        }
-    }.f);
-    try seamstress.run();
+
+    seamstress.status = .running;
+    try seamstress.loop.run(.until_done);
     try std.testing.expect(failed == false);
 }

--- a/src/timer.zig
+++ b/src/timer.zig
@@ -16,6 +16,9 @@ pub fn register(l: *Lua) i32 {
     return 1;
 }
 
+const handleFromPtr = lu.handleFromPtr;
+const ptrFromHandle = lu.ptrFromHandle;
+
 fn __cancel(l: *Lua) i32 {
     const timer = l.checkUserdata(Timer, 1, "seamstress.Timer");
     l.pushValue(1);
@@ -208,19 +211,6 @@ fn __index(l: *Lua) i32 {
     _ = l.getTable(-2); // v = t[k]
     l.remove(-2); // remove t
     return 1; // return v
-}
-
-/// converts a userdata pointer to a Lua registry index handle
-fn handleFromPtr(ptr: ?*anyopaque) i32 {
-    const @"u32": u32 = @intCast(@intFromPtr(ptr));
-    return @bitCast(@"u32");
-}
-
-/// converts a Lua registry index handle to a userdata pointer
-fn ptrFromHandle(handle: i32) ?*anyopaque {
-    const @"u32": u32 = @bitCast(handle);
-    const ptr: usize = @"u32";
-    return @ptrFromInt(ptr);
 }
 
 /// performs t[k] = v, special casing based on whether k is in the list of indices above


### PR DESCRIPTION
`zig build` now also compiles a shared library `seamstress.so` for use with external Lua interpreters.

TODO: currently a user needs to provide the environment variable SEAMSTRESS_LUA_PATH manually, but a best guess should be possible if it is not available.

seamstress.quit() is removed in favor of
seamstress:stop(). seamstress:stop() attempts to clear the event loop, but does not exit the program. new are seamstress:resume() and seamstress:run(). the former runs the event loop for one tick, while the latter takes optionally arguments fun, ..., which are fed to seamstress.async.Promise. the latter also runs the event loop until it is finished.

ptrFromHandle and handleFromPtr are now in lua_util, since that pattern seems very common, as is a basic unrefCallback.

seamstress.cli and seamstress.repl are separated into distinct modules and exposed to the module system. processChunk is removed from lua_util in favor of calling seamstress.repl directly.

BREAKING CHANGE: Lua.allocator() panics when called on a Lua instance not created by Zig, so all calls to Lua.allocator() should be replaced with calls to the allocator() function in lua_util

BREAKING CHANGE: the seamstress configuration step is removed. (running arbitrary Lua code feels less comfy lately, and most use cases are moot with, e.g. the move to providing port numbers directly)